### PR TITLE
Missing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ TODO
   /bat/{env}-session-cookie-secret
   /bat/{env}-products-import-bucket
   /bat/{env}-rollbar-env
+  /bat/{env}-spree-image-host
 ```
 
 4. Run `terraform apply`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ TODO
 	/bat/{env}-secret-key-base
   /bat/{env}-basic-auth-username
   /bat/{env}-basic-auth-password
+  /bar/{env}-basic-auth-enabled
   /bat/{env}-db-password
   /bat/{env}-session-cookie-secret
   /bat/{env}-products-import-bucket

--- a/README.md
+++ b/README.md
@@ -115,3 +115,58 @@ user.update_column(:state, 'active')
 #Confirm the update has worked.
 user.reload
 ```
+
+Seed Cnet data
+
+Manufacturers - all
+
+```
+::Cnet::Import::Manufacturers.call(path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/metamap/Distivoc.txt')
+```
+
+Categories - all
+
+```
+::Cnet::Import::Categories.call(path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/categorization/Cct_Categories.txt')
+```
+
+Products - 50k
+```
+::Cnet::Import::Products.call(path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/catalog/prod.txt', names_path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/components/stdnee.txt')
+
+```
+Product Documents - 50k
+```
+::Cnet::Import::ProductDocuments.call(path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content_Links-sample-50k.txt', names_path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content-sample-50k.txt')
+```
+
+Product Xmls - 50k
+```
+::Cnet::Import::ProductXmls.call(path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content_Links-sample-50k.txt', names_path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content-sample-50k.txt')
+
+```
+Products Categories - 50k
+```
+::Cnet::Import::ProductCategories.call(path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/categorization/Cct_Products-sample-50k.txt')
+```
+
+Product Properties - 50k
+```
+::Cnet::Import::ProductProperties.call(path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/components/especee-sample-50k.txt', names_path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/components/evocee.txt')
+```
+
+Products Images - 50k - (Images is still being worked on, though. It works, we just limiting number of duplicated images or image placeholders)
+```
+::Cnet::Import::ProductImages.call(
+  path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content_Links-sample-50k.txt',
+  image_data_path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content-sample-50k.txt',
+  attributes_path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content_Meta-sample-50k.txt',
+  attributes_dictionary_path_name: 'https://cnet-spree-staging.s3.eu-west-2.amazonaws.com/initial_import/digitalcontent/Digital_Content_Meta_Value_Voc-sample-50k.txt'
+)
+```
+
+After importing CNET data you will need to reindex Elastic search again
+
+```
+bundle exec rails searchkick:reindex:all
+```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ TODO
   /bat/{env}-basic-auth-password
   /bat/{env}-db-password
   /bat/{env}-session-cookie-secret
+  /bat/{env}-products-import-bucket
+  /bat/{env}-rollbar-env
 ```
 
 4. Run `terraform apply`

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -79,6 +79,14 @@ data "aws_ssm_parameter" "client_session_secret" {
   name = "/bat/${lower(var.environment)}-session-cookie-secret"
 }
 
+data "aws_ssm_parameter" "products_import_bucket" {
+  name = "/bat/${lower(var.environment)}-products-import-bucket"
+}
+
+data "aws_ssm_parameter" "rollbar_env" {
+  name = "/bat/${lower(var.environment)}-rollbar-env"
+}
+
 ######################################
 # Temporary solution - logs
 # - copy/paste from original
@@ -390,6 +398,8 @@ module "spree" {
   rollbar_access_token   = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username     = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
+  products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
+  rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
   redis_url              = module.memcached.redis_url
   memcached_endpoint     = module.memcached.memcached_endpoint
   security_groups        = [aws_security_group.spree.id]
@@ -420,6 +430,8 @@ module "sidekiq" {
   rollbar_access_token   = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username     = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
+  products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
+  rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
   redis_url              = module.memcached.redis_url
   security_groups        = [aws_security_group.spree.id]
   env_file               = module.s3.env_file_spree
@@ -451,4 +463,5 @@ module "client" {
   security_groups       = [aws_security_group.client.id]
   env_file              = module.s3.env_file_client
   cloudfront_id         = data.aws_ssm_parameter.cloudfront_id.value
+  rollbar_env           = data.aws_ssm_parameter.rollbar_env.value
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -87,6 +87,9 @@ data "aws_ssm_parameter" "rollbar_env" {
   name = "/bat/${lower(var.environment)}-rollbar-env"
 }
 
+data "aws_ssm_parameter" "spree_image_host" {
+  name = "/bat/${lower(var.environment)}-spree-image-host"
+}
 ######################################
 # Temporary solution - logs
 # - copy/paste from original
@@ -464,4 +467,6 @@ module "client" {
   env_file              = module.s3.env_file_client
   cloudfront_id         = data.aws_ssm_parameter.cloudfront_id.value
   rollbar_env           = data.aws_ssm_parameter.rollbar_env.value
+  spree_image_host      = data.aws_ssm_parameter.spree_image_host.value
+
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -71,6 +71,10 @@ data "aws_ssm_parameter" "basic_auth_password" {
   name = "/bat/${lower(var.environment)}-basic-auth-password"
 }
 
+data "aws_ssm_parameter" "basic_auth_enabled" {
+  name = "/bat/${lower(var.environment)}-basic-auth-enabled"
+}
+
 data "aws_ssm_parameter" "db_password" {
   name = "/bat/${lower(var.environment)}-db-password"
 }
@@ -401,6 +405,7 @@ module "spree" {
   rollbar_access_token   = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username     = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
+  basicauth_enabled     = data.aws_ssm_parameter.basic_auth_enabled.value
   products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
   rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
   redis_url              = module.memcached.redis_url
@@ -433,6 +438,7 @@ module "sidekiq" {
   rollbar_access_token   = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username     = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
+  basicauth_enabled     = data.aws_ssm_parameter.basic_auth_enabled.value
   products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
   rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
   redis_url              = module.memcached.redis_url
@@ -462,6 +468,7 @@ module "client" {
   rollbar_access_token  = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username    = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password    = data.aws_ssm_parameter.basic_auth_password.value
+  basicauth_enabled     = data.aws_ssm_parameter.basic_auth_enabled.value
   client_session_secret = data.aws_ssm_parameter.client_session_secret.value
   security_groups       = [aws_security_group.client.id]
   env_file              = module.s3.env_file_client

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -34,3 +34,8 @@ resource "aws_s3_bucket_object" "env-client" {
   key     = "client.env"
   acl     = "private"
 }
+
+resource "aws_s3_bucket" "product-import" {
+  bucket        = "spree-${lower(var.environment)}-products-import"
+  force_destroy = true
+}

--- a/terraform/modules/services/client/client.json.tpl
+++ b/terraform/modules/services/client/client.json.tpl
@@ -51,6 +51,10 @@
       {
         "name": "ROLLBAR_ENV",
         "value": "${rollbar_env}"
+      },
+      {
+        "name": "SPREE_IMAGE_HOST",
+        "value": "${spree_image_host}"
       }
     ],
     "command": [

--- a/terraform/modules/services/client/client.json.tpl
+++ b/terraform/modules/services/client/client.json.tpl
@@ -41,6 +41,10 @@
         "value": "${basicauth_password}"
       },
       {
+        "name": "BASICAUTH_ENABLED",
+        "value": "${basicauth_enabled}"
+      },
+      {
         "name": "SPREE_API_HOST",
         "value": "http://${spree_api_host}"
       },

--- a/terraform/modules/services/client/client.json.tpl
+++ b/terraform/modules/services/client/client.json.tpl
@@ -20,25 +20,25 @@
       }
     ],
     "environment": [
-      { 
-        "name": "API_HOST", 
-        "value": "${api_host}" 
+      {
+        "name": "API_HOST",
+        "value": "${api_host}"
       },
-      { 
-        "name": "PORT", 
-        "value": "${app_port}" 
+      {
+        "name": "PORT",
+        "value": "${app_port}"
       },
-      { 
-        "name": "ROLLBAR_ACCESS_TOKEN", 
-        "value": "${rollbar_access_token}" 
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "value": "${rollbar_access_token}"
       },
-      { 
-        "name": "BASICAUTH_USERNAME", 
-        "value": "${basicauth_username}" 
+      {
+        "name": "BASICAUTH_USERNAME",
+        "value": "${basicauth_username}"
       },
-      { 
-        "name": "BASICAUTH_PASSWORD", 
-        "value": "${basicauth_password}" 
+      {
+        "name": "BASICAUTH_PASSWORD",
+        "value": "${basicauth_password}"
       },
       {
         "name": "SPREE_API_HOST",
@@ -47,6 +47,10 @@
       {
         "name": "SESSION_COOKIE_SECRET",
         "value": "${client_session_secret}"
+      },
+      {
+        "name": "ROLLBAR_ENV",
+        "value": "${rollbar_env}"
       }
     ],
     "command": [

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -73,6 +73,7 @@ data "template_file" "app_client" {
     rollbar_access_token  = var.rollbar_access_token
     basicauth_username    = var.basicauth_username
     basicauth_password    = var.basicauth_password
+    basicauth_enabled     = var.basicauth_enabled
     rollbar_env           = var.rollbar_env
     spree_image_host      = var.spree_image_host
     env_file              = var.env_file

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -74,6 +74,7 @@ data "template_file" "app_client" {
     basicauth_username    = var.basicauth_username
     basicauth_password    = var.basicauth_password
     rollbar_env           = var.rollbar_env
+    spree_image_host      = var.spree_image_host
     env_file              = var.env_file
     client_session_secret = var.client_session_secret
   }

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -73,6 +73,7 @@ data "template_file" "app_client" {
     rollbar_access_token  = var.rollbar_access_token
     basicauth_username    = var.basicauth_username
     basicauth_password    = var.basicauth_password
+    rollbar_env           = var.rollbar_env
     env_file              = var.env_file
     client_session_secret = var.client_session_secret
   }

--- a/terraform/modules/services/client/variables.tf
+++ b/terraform/modules/services/client/variables.tf
@@ -63,6 +63,10 @@ variable "client_session_secret" {
   type = string
 }
 
+variable "rollbar_env" {
+  type = string
+}
+
 variable "execution_role_arn" {
   type = string
 }

--- a/terraform/modules/services/client/variables.tf
+++ b/terraform/modules/services/client/variables.tf
@@ -59,6 +59,10 @@ variable "basicauth_password" {
   type = string
 }
 
+variable "basicauth_enabled" {
+  type = string
+}
+
 variable "client_session_secret" {
   type = string
 }

--- a/terraform/modules/services/client/variables.tf
+++ b/terraform/modules/services/client/variables.tf
@@ -67,6 +67,10 @@ variable "rollbar_env" {
   type = string
 }
 
+variable "spree_image_host" {
+  type = string
+}
+
 variable "execution_role_arn" {
   type = string
 }

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -21,6 +21,7 @@ data "template_file" "app_sidekiq" {
     secret_key_base            = var.secret_key_base
     basicauth_username         = var.basicauth_username
     basicauth_password         = var.basicauth_password
+    basicauth_enabled          = var.basicauth_enabled
     rollbar_spree_access_token = var.rollbar_access_token
     products_import_bucket     = var.products_import_bucket
     rollbar_env                = var.rollbar_env

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -22,6 +22,8 @@ data "template_file" "app_sidekiq" {
     basicauth_username         = var.basicauth_username
     basicauth_password         = var.basicauth_password
     rollbar_spree_access_token = var.rollbar_access_token
+    products_import_bucket     = var.products_import_bucket
+    rollbar_env                = var.rollbar_env
     env_file                   = var.env_file
     redis_url                  = var.redis_url
   }

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -7,7 +7,7 @@ data "template_file" "app_sidekiq" {
   template = file("${path.module}/sidekiq.json.tpl")
 
   vars = {
-    //app_image                  = "${aws_ecr_repository.spree.repository_url}:latest"
+    //app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/spree-service-staging:hello-world-test-4567"
     app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/spree-service-staging:latest"
     app_port                   = var.app_port
     fargate_cpu                = var.cpu

--- a/terraform/modules/services/sidekiq/sidekiq.json.tpl
+++ b/terraform/modules/services/sidekiq/sidekiq.json.tpl
@@ -49,6 +49,10 @@
         "value": "${basicauth_password}"
       },
       {
+        "name": "BASICAUTH_ENABLED",
+        "value": "${basicauth_enabled}"
+      },
+      {
         "name": "ROLLBAR_ACCESS_TOKEN",
         "value": "${rollbar_spree_access_token}"
       },

--- a/terraform/modules/services/sidekiq/sidekiq.json.tpl
+++ b/terraform/modules/services/sidekiq/sidekiq.json.tpl
@@ -20,41 +20,49 @@
       }
     ],
     "environment": [
-      { 
-        "name": "DB_NAME", 
-        "value": "${db_name}" 
+      {
+        "name": "DB_NAME",
+        "value": "${db_name}"
       },
-      { 
-        "name": "DB_HOST", 
-        "value": "${db_host}" 
+      {
+        "name": "DB_HOST",
+        "value": "${db_host}"
       },
-      { 
-        "name": "DB_USERNAME", 
-        "value": "${db_username}" 
+      {
+        "name": "DB_USERNAME",
+        "value": "${db_username}"
       },
-      { 
-        "name": "DB_PASSWORD", 
-        "value": "${db_password}" 
+      {
+        "name": "DB_PASSWORD",
+        "value": "${db_password}"
       },
       {
         "name": "SECRET_KEY_BASE",
         "value": "${secret_key_base}"
       },
-      { 
-        "name": "BASICAUTH_USERNAME", 
-        "value": "${basicauth_username}" 
+      {
+        "name": "BASICAUTH_USERNAME",
+        "value": "${basicauth_username}"
       },
-      { 
-        "name": "BASICAUTH_PASSWORD", 
-        "value": "${basicauth_password}" 
+      {
+        "name": "BASICAUTH_PASSWORD",
+        "value": "${basicauth_password}"
       },
-      { 
-        "name": "ROLLBAR_ACCESS_TOKEN", 
-        "value": "${rollbar_spree_access_token}" 
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "value": "${rollbar_spree_access_token}"
       },
       {
         "name": "REDIS_URL",
         "value": "${redis_url}"
+      },
+      {
+        "name": "PRODUCTS_IMPORT_BUCKET",
+        "value": "${products_import_bucket}"
+      },
+      {
+        "name": "ROLLBAR_ENV",
+        "value": "${rollbar_env}"
       }
     ],
     "command": [

--- a/terraform/modules/services/sidekiq/variables.tf
+++ b/terraform/modules/services/sidekiq/variables.tf
@@ -66,6 +66,14 @@ variable "basicauth_password" {
   type = string
 }
 
+variable "products_import_bucket" {
+  type = string
+}
+
+variable "rollbar_env" {
+  type = string
+}
+
 variable "env_file" {
   type = string
 }

--- a/terraform/modules/services/sidekiq/variables.tf
+++ b/terraform/modules/services/sidekiq/variables.tf
@@ -66,6 +66,10 @@ variable "basicauth_password" {
   type = string
 }
 
+variable "basicauth_enabled" {
+  type = string
+}
+
 variable "products_import_bucket" {
   type = string
 }

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -106,6 +106,7 @@ data "template_file" "app_client" {
     secret_key_base            = var.secret_key_base
     basicauth_username         = var.basicauth_username
     basicauth_password         = var.basicauth_password
+    basicauth_enabled          = var.basicauth_enabled
     rollbar_spree_access_token = var.rollbar_access_token
     products_import_bucket     = var.products_import_bucket
     rollbar_env                = var.rollbar_env

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -107,6 +107,8 @@ data "template_file" "app_client" {
     basicauth_username         = var.basicauth_username
     basicauth_password         = var.basicauth_password
     rollbar_spree_access_token = var.rollbar_access_token
+    products_import_bucket     = var.products_import_bucket
+    rollbar-env                = var.rollbar_env
     env_file                   = var.env_file
     redis_url                  = var.redis_url
     memcached_endpoint         = var.memcached_endpoint

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -108,7 +108,7 @@ data "template_file" "app_client" {
     basicauth_password         = var.basicauth_password
     rollbar_spree_access_token = var.rollbar_access_token
     products_import_bucket     = var.products_import_bucket
-    rollbar-env                = var.rollbar_env
+    rollbar_env                = var.rollbar_env
     env_file                   = var.env_file
     redis_url                  = var.redis_url
     memcached_endpoint         = var.memcached_endpoint

--- a/terraform/modules/services/spree/spree.json.tpl
+++ b/terraform/modules/services/spree/spree.json.tpl
@@ -20,37 +20,37 @@
       }
     ],
     "environment": [
-      { 
-        "name": "DB_NAME", 
-        "value": "${db_name}" 
+      {
+        "name": "DB_NAME",
+        "value": "${db_name}"
       },
-      { 
-        "name": "DB_HOST", 
-        "value": "${db_host}" 
+      {
+        "name": "DB_HOST",
+        "value": "${db_host}"
       },
-      { 
-        "name": "DB_USERNAME", 
-        "value": "${db_username}" 
+      {
+        "name": "DB_USERNAME",
+        "value": "${db_username}"
       },
-      { 
-        "name": "DB_PASSWORD", 
-        "value": "${db_password}" 
+      {
+        "name": "DB_PASSWORD",
+        "value": "${db_password}"
       },
       {
         "name": "SECRET_KEY_BASE",
         "value": "${secret_key_base}"
       },
-      { 
-        "name": "BASICAUTH_USERNAME", 
-        "value": "${basicauth_username}" 
+      {
+        "name": "BASICAUTH_USERNAME",
+        "value": "${basicauth_username}"
       },
-      { 
-        "name": "BASICAUTH_PASSWORD", 
-        "value": "${basicauth_password}" 
+      {
+        "name": "BASICAUTH_PASSWORD",
+        "value": "${basicauth_password}"
       },
-      { 
-        "name": "ROLLBAR_ACCESS_TOKEN", 
-        "value": "${rollbar_spree_access_token}" 
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "value": "${rollbar_spree_access_token}"
       },
       {
         "name": "REDIS_URL",
@@ -59,6 +59,14 @@
       {
         "name": "MEMCACHED_ENDPOINT",
         "value": "${memcached_endpoint}:11211"
+      },
+      {
+        "name": "PRODUCTS_IMPORT_BUCKET",
+        "value": "${products_import_bucket}"
+      },
+      {
+        "name": "ROLLBAR_ENV",
+        "value": "${rollbar_env}"
       }
     ],
     "command": [

--- a/terraform/modules/services/spree/spree.json.tpl
+++ b/terraform/modules/services/spree/spree.json.tpl
@@ -49,6 +49,10 @@
         "value": "${basicauth_password}"
       },
       {
+        "name": "BASICAUTH_ENABLED",
+        "value": "${basicauth_enabled}"
+      },
+      {
         "name": "ROLLBAR_ACCESS_TOKEN",
         "value": "${rollbar_spree_access_token}"
       },

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -74,6 +74,14 @@ variable "basicauth_password" {
   type = string
 }
 
+variable "products_import_bucket" {
+  type = string
+}
+
+variable "rollbar_env" {
+  type = string
+}
+
 variable "env_file" {
   type = string
 }

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -74,6 +74,10 @@ variable "basicauth_password" {
   type = string
 }
 
+variable "basicauth_enabled" {
+  type = string
+}
+
 variable "products_import_bucket" {
   type = string
 }


### PR DESCRIPTION
-  Add missing env variables

   `products-import-bucket` (where product updates will be process)
   `rollbar-env` (differentiate between the different environments errors in rollbar)
  `spree-image-host` ( use the external load balance url for image in client) * hack around the https issue

- Add missing product import bucket (wasn't in the original terraform, must have been created in the console)

- Update readme with how to seed the full CNET data