### PR TITLE
SINF-135 - installed Instance Connect and updated AMI

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -13,14 +13,19 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
 }
 
 resource "aws_launch_configuration" "ecs-launch-configuration" {
-  name                        = "megapool"
-  image_id                    = "ami-005307409c5f6e76c"
+  name_prefix                 = "megapool-"
+  image_id                    = "ami-09f5dea513082ee2d"
   iam_instance_profile        = aws_iam_instance_profile.ecs_agent.name
   user_data                   = data.template_file.user_data.rendered
   instance_type               = "t2.large"
   associate_public_ip_address = true
   key_name                    = "${lower(var.environment)}-spree-key"
   security_groups             = var.security_group_ids
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
 }
 
 data "template_file" "user_data" {

--- a/terraform/modules/ecs/user_data.tpl
+++ b/terraform/modules/ecs/user_data.tpl
@@ -1,2 +1,4 @@
 #!/bin/bash
 echo ECS_CLUSTER=cb-cluster >> /etc/ecs/ecs.config
+
+sudo yum install -y ec2-instance-connect


### PR DESCRIPTION
This will install `ec2-instance-connect` on BaT EC2 instances.

Changes to `name` and `lifecycle` to allow Terraform to automatically update (which requires a destroy/create, so complains otherwise and have to do via console). Name will probably change again anyway when we do the resource rename.

Changes to `image_id` as the current image uses `Amazon ECS-Optimized Amazon Linux AMI 2018.03.f` which does not support instance connect, and support ends in December - Amazon recommend upgrading to Amazon Linux 2 (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html)

The updated version uses the latest image as recommended at https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html

If this looks ok - I will send an email to Damian to check this is ok from their point of view