### PR TITLE
Restrict BaT ports to agreed ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ S3_BUCKET_NAME=spree-${lower(var.environment)}-${lower(var.stage)}
 ELASTICSEARCH_URL={URL_FOR_ELASTIC_SEARCH_PROVISIONED_IN_THESE_SCRIPTS}
 ```
 
-7. Update the services
+7. Upload `client.env` and `spree.env` to the provisioned S3 bucket `system-spree-[env]-staging`
+
+8. Update the services
  - simple hack for this is to change the docker image to some random id - run `terraform apply`
  - then switch it to 'latest' again and rerun `terraform apply`
  - this whole part of the process needs review

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TODO
 ### Pre install steps
 
 1. Create IAM user called `spree-user` with policy (`app-policy`) allowing full access to S3 (TODO: this needs to be reviewed/tied down)
-  - Add AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY valies to `spree.env`
+  - Add AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY values to `spree.env`
 
 2. Create an key pair instance called `{env}-spree-key'`
 

--- a/terraform/environments/sbx2/main.tf
+++ b/terraform/environments/sbx2/main.tf
@@ -1,0 +1,33 @@
+#########################################################
+# Environment: SBX2
+#
+# Deploy SCALE resources
+#########################################################
+terraform {
+  backend "s3" {
+    bucket         = "scale-terraform-state"
+    key            = "ccs-scale-infra-services-bat-sbx2"
+    region         = "eu-west-2"
+    dynamodb_table = "scale_terraform_state_lock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "eu-west-2"
+}
+
+locals {
+  environment = "SBX2"
+}
+
+data "aws_ssm_parameter" "aws_account_id" {
+  name = "account-id-${lower(local.environment)}"
+}
+
+module "deploy" {
+  source         = "../../modules/configs/deploy-all"
+  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
+  environment    = local.environment
+}

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -94,6 +94,33 @@ data "aws_ssm_parameter" "rollbar_env" {
 data "aws_ssm_parameter" "spree_image_host" {
   name = "/bat/${lower(var.environment)}-spree-image-host"
 }
+
+######################################
+# CIDR ranges for whitelisting
+######################################
+data "aws_ssm_parameter" "cidr_blocks_allowed_external_ccs" {
+  name = "${lower(var.environment)}-cidr-blocks-allowed-external-ccs"
+}
+
+data "aws_ssm_parameter" "cidr_blocks_allowed_external_spark" {
+  name = "${lower(var.environment)}-cidr-blocks-allowed-external-spark"
+}
+
+data "aws_ssm_parameter" "cidr_blocks_allowed_external_cognizant" {
+  name = "${lower(var.environment)}-cidr-blocks-allowed-external-cognizant"
+}
+
+locals {
+  # Normalised CIDR blocks (accounting for 'none' i.e. "-" as value in SSM parameter)
+  cidr_blocks_allowed_external_ccs       = data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value) : []
+  cidr_blocks_allowed_external_spark     = data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value) : []
+  cidr_blocks_allowed_external_cognizant = data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value) : []
+}
+
+data "aws_vpc" "scale" {
+  id = data.aws_ssm_parameter.vpc_id.value
+}
+
 ######################################
 # Temporary solution - logs
 # - copy/paste from original
@@ -128,17 +155,15 @@ resource "aws_security_group_rule" "spree-allow-ssh" {
   to_port           = 22
   protocol          = "tcp"
   security_group_id = aws_security_group.spree.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, tolist([data.aws_vpc.scale.cidr_block]))
 }
 resource "aws_security_group_rule" "spree-allow-http" {
-  type      = "ingress"
-  from_port = 80
-  to_port   = 80
-  # from_port         = 8081
-  # to_port           = 8081
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
   protocol          = "tcp"
   security_group_id = aws_security_group.spree.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, tolist([data.aws_vpc.scale.cidr_block]))
 }
 resource "aws_security_group_rule" "spree-allow-https" {
   type              = "ingress"
@@ -164,7 +189,7 @@ resource "aws_security_group_rule" "spree-test" {
   to_port           = 4567
   protocol          = "tcp"
   security_group_id = aws_security_group.spree.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [data.aws_vpc.scale.cidr_block]
 }
 
 resource "aws_security_group" "client" {
@@ -178,17 +203,15 @@ resource "aws_security_group_rule" "client-allow-ssh" {
   to_port           = 22
   protocol          = "tcp"
   security_group_id = aws_security_group.client.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, tolist([data.aws_vpc.scale.cidr_block]))
 }
 resource "aws_security_group_rule" "client-allow-http" {
-  type = "ingress"
-  //from_port         = 80
-  //to_port           = 80
+  type              = "ingress"
   from_port         = 8080
   to_port           = 8080
   protocol          = "tcp"
   security_group_id = aws_security_group.client.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [data.aws_vpc.scale.cidr_block]
 }
 resource "aws_security_group_rule" "client-allow-https" {
   type              = "ingress"
@@ -218,17 +241,15 @@ resource "aws_security_group_rule" "rds-allow-psql" {
   to_port           = 5432
   protocol          = "tcp"
   security_group_id = aws_security_group.rds.id
-  #source_security_group_id = aws_security_group.spree.id
-  #temporarily modified to allow access via bastion host
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks       = [data.aws_vpc.scale.cidr_block]
 }
 resource "aws_security_group_rule" "rds-allow-outgoing" {
   type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
   security_group_id = aws_security_group.rds.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [data.aws_vpc.scale.cidr_block]
 }
 
 resource "aws_security_group" "redis" {
@@ -240,7 +261,7 @@ resource "aws_security_group" "redis" {
     protocol    = "tcp"
     from_port   = 6379
     to_port     = 6379
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [data.aws_vpc.scale.cidr_block]
   }
 
   egress {
@@ -259,7 +280,7 @@ resource "aws_security_group" "memcached" {
     protocol    = "tcp"
     from_port   = 11211
     to_port     = 11211
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [data.aws_vpc.scale.cidr_block]
   }
 
   egress {
@@ -275,11 +296,10 @@ resource "aws_security_group" "es" {
   vpc_id = data.aws_ssm_parameter.vpc_id.value
 
   ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, tolist([data.aws_vpc.scale.cidr_block]))
   }
 
   egress {
@@ -405,7 +425,7 @@ module "spree" {
   rollbar_access_token   = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username     = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
-  basicauth_enabled     = data.aws_ssm_parameter.basic_auth_enabled.value
+  basicauth_enabled      = data.aws_ssm_parameter.basic_auth_enabled.value
   products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
   rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
   redis_url              = module.memcached.redis_url
@@ -438,7 +458,7 @@ module "sidekiq" {
   rollbar_access_token   = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username     = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
-  basicauth_enabled     = data.aws_ssm_parameter.basic_auth_enabled.value
+  basicauth_enabled      = data.aws_ssm_parameter.basic_auth_enabled.value
   products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
   rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
   redis_url              = module.memcached.redis_url

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -27,24 +27,3 @@ resource "aws_elasticsearch_domain" "main" {
     aws_iam_service_linked_role.es,
   ]
 }
-
-# resource "aws_elasticsearch_domain_policy" "main" {
-#   domain_name = aws_elasticsearch_domain.main.domain_name
-#
-#   access_policies = <<POLICIES
-# {
-#     "Version": "2012-10-17",
-#     "Statement": [
-#         {
-#             "Action": "es:*",
-#             "Principal": "*",
-#             "Effect": "Allow",
-#             "Condition": {
-#                 "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
-#             },
-#             "Resource": "${aws_elasticsearch_domain.example.arn}/*"
-#         }
-#     ]
-# }
-# POLICIES
-# }

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -27,3 +27,23 @@ resource "aws_elasticsearch_domain" "main" {
     aws_iam_service_linked_role.es,
   ]
 }
+
+resource "aws_elasticsearch_domain_policy" "main" {
+  domain_name = aws_elasticsearch_domain.main.domain_name
+
+  access_policies = <<POLICIES
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "es:*",
+            "Principal": {
+              "AWS": "*"
+            },
+            "Resource": "${aws_elasticsearch_domain.main.arn}/*"
+        }
+    ]
+}
+POLICIES
+}

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -27,3 +27,24 @@ resource "aws_elasticsearch_domain" "main" {
     aws_iam_service_linked_role.es,
   ]
 }
+
+# resource "aws_elasticsearch_domain_policy" "main" {
+#   domain_name = aws_elasticsearch_domain.main.domain_name
+#
+#   access_policies = <<POLICIES
+# {
+#     "Version": "2012-10-17",
+#     "Statement": [
+#         {
+#             "Action": "es:*",
+#             "Principal": "*",
+#             "Effect": "Allow",
+#             "Condition": {
+#                 "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
+#             },
+#             "Resource": "${aws_elasticsearch_domain.example.arn}/*"
+#         }
+#     ]
+# }
+# POLICIES
+# }

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -24,5 +24,6 @@ resource "aws_db_instance" "rds-app-prod" {
   vpc_security_group_ids      = var.security_group_ids
   skip_final_snapshot         = false
   final_snapshot_identifier   = "final-snaphot-appstaging-${uuid()}"
-  snapshot_identifier         = "snapshot-prior-to-destroy-and-recreate-27082020"
+  snapshot_identifier         = "arn:aws:rds:eu-west-2:464702836434:snapshot:sbx1-old-version-snapshot-sbx2"
+  storage_encrypted           = true
 }

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -24,6 +24,6 @@ resource "aws_db_instance" "rds-app-prod" {
   vpc_security_group_ids      = var.security_group_ids
   skip_final_snapshot         = false
   final_snapshot_identifier   = "final-snaphot-appstaging-${uuid()}"
-  snapshot_identifier         = "arn:aws:rds:eu-west-2:464702836434:snapshot:sbx1-old-version-snapshot-sbx2"
-  storage_encrypted           = true
+  snapshot_identifier         = "snapshot-prior-to-destroy-and-recreate-27082020"
+  # storage_encrypted           = true
 }

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -51,6 +51,30 @@ resource "aws_lb_listener" "port_80" {
   }
 }
 
+# TEMPORARY - REFACTOR - JUST MIMICS MANUAL CHANGES IN CONSOLE
+# Data sources for the ALB custom domain name and SSL certificate
+data "aws_ssm_parameter" "hosted_zone_name_alb" {
+  name = "${lower(var.environment)}-hosted-zone-name-alb"
+}
+
+data "aws_acm_certificate" "alb" {
+  domain   = data.aws_ssm_parameter.hosted_zone_name_alb.value
+  statuses = ["ISSUED"]
+}
+
+resource "aws_lb_listener" "port_443" {
+  load_balancer_arn = var.lb_public_alb_arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = data.aws_acm_certificate.alb.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group_4567.arn
+  }
+}
+
 #######################################################################
 # NLB target group & listener for traffic on port 80 -> 4567 (Spree app)
 # through the internal NLB for connections from the client app
@@ -128,11 +152,13 @@ resource "aws_ecs_task_definition" "app_spree" {
 
 
 resource "aws_ecs_service" "spree" {
-  name            = "spree-service"
-  cluster         = var.ecs_cluster_id
-  task_definition = aws_ecs_task_definition.app_spree.arn
-  desired_count   = 1
-  launch_type     = "EC2"
+  name                               = "spree-service"
+  cluster                            = var.ecs_cluster_id
+  task_definition                    = aws_ecs_task_definition.app_spree.arn
+  desired_count                      = 1
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+  launch_type                        = "EC2"
 
   network_configuration {
     security_groups = var.security_groups

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -152,13 +152,10 @@ resource "aws_ecs_task_definition" "app_spree" {
 
 
 resource "aws_ecs_service" "spree" {
-  name                               = "spree-service"
-  cluster                            = var.ecs_cluster_id
-  task_definition                    = aws_ecs_task_definition.app_spree.arn
-  desired_count                      = 1
-  deployment_maximum_percent         = 200
-  deployment_minimum_healthy_percent = 100
-  launch_type                        = "EC2"
+  name            = "spree-service"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.app_spree.arn
+  launch_type     = "EC2"
 
   network_configuration {
     security_groups = var.security_groups


### PR DESCRIPTION
First pass at this based on the spreadsheet(s).  Re-uses the same CIDR block SSM params as for the bastion host access, just in different combinations as required and combined with the scale VPC CIDR block for completeness in most cases.

I am still in the process of provisioning BaT in SBX2 so can't verify any of this as having not broken anything yet - but you chaps might be able to I guess.  Wasn't sure about ElasticSearch - ignore the policy bit in there at the moment, I'm still trying to figure out what needs to be done there (if anything).