### PR TITLE
Feature/sinf 83 rename resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Check the README file for details of how to create the database.
 5. Create `client.env` environment file
 
 ```
-#SPREE_API_HOST=http://{DOMAIN_NAME_OF_SPREE_SERVICE_LOAD_BALANCER}
 SESSION_COOKIE_SECRET={RANDOM_STRING? NOT SURE}
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Check the README file for details of how to create the database.
   /bat/{env}-session-cookie-secret
   /bat/{env}-products-import-bucket
   /bat/{env}-rollbar-env
-  /bat/{env}-spree-image-host
 ```
 
 4. Run `terraform apply`
@@ -38,7 +37,7 @@ Check the README file for details of how to create the database.
 5. Create `client.env` environment file
 
 ```
-SPREE_API_HOST=http://{DOMAIN_NAME_OF_SPREE_SERVICE_LOAD_BALANCER}
+#SPREE_API_HOST=http://{DOMAIN_NAME_OF_SPREE_SERVICE_LOAD_BALANCER}
 SESSION_COOKIE_SECRET={RANDOM_STRING? NOT SURE}
 ```
 
@@ -47,16 +46,13 @@ SESSION_COOKIE_SECRET={RANDOM_STRING? NOT SURE}
 ```
 SIDEKIQ_USERNAME={}
 SIDEKIQ_PASSWORD={}
-BUYER_UI_URL=https://{DOMAIN_NAME_OF_CLIENT_LOAD_BALANCER}
 SENDGRID_USERNAME={}
 SENDGRID_PASSWORD={}
-APP_DOMAIN={DOMAIN_NAME_OF_SPREE_SERVICE_LOAD_BALANCER}
 AWS_REGION=eu-west-2
 AWS_ACCESS_KEY_ID={VALUE_FROM_IAM_USER_ABOVE}
 AWS_SECRET_ACCESS_KEY={VALUE_FROM_IAM_USER_ABOVE}
 S3_REGION=eu-west-2
 S3_BUCKET_NAME=spree-${lower(var.environment)}-${lower(var.stage)}
-ELASTICSEARCH_URL={URL_FOR_ELASTIC_SEARCH_PROVISIONED_IN_THESE_SCRIPTS}
 ```
 
 7. Upload `client.env` and `spree.env` to the provisioned S3 bucket `system-spree-[env]-staging`

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -27,7 +27,9 @@ data "aws_ssm_parameter" "aws_account_id" {
 }
 
 module "deploy" {
-  source         = "../../modules/configs/deploy-all"
-  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
-  environment    = local.environment
+  source              = "../../modules/configs/deploy-all"
+  aws_account_id      = data.aws_ssm_parameter.aws_account_id.value
+  environment         = local.environment
+  ecr_image_id_spree  = "latest"
+  ecr_image_id_client = "latest"
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -326,7 +326,7 @@ data "aws_iam_policy_document" "ecs_task_execution_role" {
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name               = "ECSTaskExecutionRole"
+  name               = "SCALE_ECS_BAT_Services_Task_Execution"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
 }
 
@@ -352,6 +352,7 @@ module "s3" {
 
 module "memcached" {
   source                       = "../../memcached"
+  environment                  = var.environment
   vpc_id                       = data.aws_ssm_parameter.vpc_id.value
   private_app_subnet_ids       = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
   security_group_memcached_ids = [aws_security_group.memcached.id]

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -88,10 +88,6 @@ data "aws_ssm_parameter" "rollbar_env" {
   name = "/bat/${lower(var.environment)}-rollbar-env"
 }
 
-#data "aws_ssm_parameter" "spree_image_host" {
-#  name = "/bat/${lower(var.environment)}-spree-image-host"
-#}
-
 data "aws_ssm_parameter" "spree_db_username" {
   name            = "/bat/${lower(var.environment)}-spree-db-app-username"
   with_decryption = true
@@ -103,7 +99,7 @@ data "aws_ssm_parameter" "spree_db_password" {
 }
 
 data "aws_ssm_parameter" "elasticsearch_url" {
-  name = "/bat/sbx1-elasticsearch-url"
+  name = "/bat/${lower(var.environment)}-elasticsearch-url"
 }
 
 ######################################

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -129,24 +129,6 @@ data "aws_vpc" "scale" {
 }
 
 ######################################
-# Temporary solution - logs
-# - copy/paste from original
-######################################
-resource "aws_cloudwatch_log_group" "cb_log_group" {
-  name              = "/ecs/cb-app"
-  retention_in_days = 30
-
-  tags = {
-    Name = "cb-log-group"
-  }
-}
-
-resource "aws_cloudwatch_log_stream" "cb_log_stream" {
-  name           = "cb-log-stream"
-  log_group_name = aws_cloudwatch_log_group.cb_log_group.name
-}
-
-######################################
 # Temporary solution - security groups
 # - copy/paste from original
 ######################################

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -7,7 +7,7 @@ variable "environment" {
 }
 
 variable "stage" {
-  type = string
+  type    = string
   default = "staging"
 }
 
@@ -19,4 +19,14 @@ variable "api_rate_limit" {
 variable "api_burst_limit" {
   type    = number
   default = 5000
+}
+
+variable "ecr_image_id_spree" {
+  type    = string
+  default = "latest"
+}
+
+variable "ecr_image_id_client" {
+  type    = string
+  default = "latest"
 }

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -4,10 +4,11 @@
 # ECS shared resources
 ##########################################################
 module "globals" {
-  source = "../globals"
+  source      = "../globals"
+  environment = var.environment
 }
 
-locals{
+locals {
   cluster_name = "SCALE-EU2-${var.environment}-APP-ECS_BAT"
 }
 

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -10,6 +10,13 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   desired_capacity = 3
   min_size         = 3
   max_size         = 3
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "AUTOSCALINGGROUP"
+  }
 }
 
 resource "aws_launch_configuration" "ecs-launch-configuration" {
@@ -25,7 +32,6 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
   lifecycle {
     create_before_destroy = true
   }
-
 }
 
 data "template_file" "user_data" {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,26 +1,32 @@
+##########################################################
+# ECS
+#
+# ECS shared resources
+##########################################################
+module "globals" {
+  source = "../globals"
+}
+
+locals{
+  cluster_name = "SCALE-EU2-${var.environment}-APP-ECS_BAT"
+}
+
 resource "aws_ecs_cluster" "main" {
-  name = "cb-cluster"
+  name = local.cluster_name
 }
 
 resource "aws_autoscaling_group" "ecs-autoscaling-group" {
-  name                 = "ecs-autoscaling-group"
+  name                 = "SCALE-EU2-${var.environment}-APP-ECS_BAT"
   vpc_zone_identifier  = var.public_web_subnet_ids
   launch_configuration = aws_launch_configuration.ecs-launch-configuration.name
 
   desired_capacity = 3
   min_size         = 3
   max_size         = 3
-
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "AUTOSCALINGGROUP"
-  }
 }
 
 resource "aws_launch_configuration" "ecs-launch-configuration" {
-  name_prefix                 = "megapool-"
+  name_prefix                 = "SCALE-EU2-${var.environment}-ASG-LC_BAT_"
   image_id                    = "ami-09f5dea513082ee2d"
   iam_instance_profile        = aws_iam_instance_profile.ecs_agent.name
   user_data                   = data.template_file.user_data.rendered
@@ -38,7 +44,7 @@ data "template_file" "user_data" {
   template = file("${path.module}/user_data.tpl")
 
   vars = {
-    cluster_name = "cb-cluster"
+    cluster_name = local.cluster_name
   }
 }
 

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -50,7 +50,7 @@ data "template_file" "user_data" {
 
 # Define the role.
 resource "aws_iam_role" "ecs_agent" {
-  name               = "ecs-agent"
+  name               = "SCALE_ECS_BAT_Services_ECS_Agent"
   assume_role_policy = data.aws_iam_policy_document.ecs_agent.json
 }
 
@@ -73,6 +73,6 @@ resource "aws_iam_role_policy_attachment" "ecs_agent" {
 }
 
 resource "aws_iam_instance_profile" "ecs_agent" {
-  name = "ecs-agent"
+  name = aws_iam_role.ecs_agent.name
   role = aws_iam_role.ecs_agent.name
 }

--- a/terraform/modules/ecs/user_data.tpl
+++ b/terraform/modules/ecs/user_data.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
-echo ECS_CLUSTER=cb-cluster >> /etc/ecs/ecs.config
+echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
 
 sudo yum install -y ec2-instance-connect

--- a/terraform/modules/globals/outputs.tf
+++ b/terraform/modules/globals/outputs.tf
@@ -7,6 +7,10 @@ locals {
   }
 }
 
+variable "environment" {
+  type = string
+}
+
 output "env_accounts" {
   value = local.env_accounts
 }
@@ -23,10 +27,10 @@ output "allowed_cors_headers" {
   ]
 }
 
-output "project_name" {
-  value = "SCALE"
-}
-
-output "project_cost_code" {
-  value = "PR2-00001"
+output "project_resource_tags" {
+  value = {
+    Project     = "SCALE"
+    Environment = upper(var.environment)
+    Cost_Code   = "PR2-00001"
+  }
 }

--- a/terraform/modules/load-balancer/main.tf
+++ b/terraform/modules/load-balancer/main.tf
@@ -62,11 +62,6 @@ resource "aws_security_group" "public_alb_cf_global" {
     Environment = upper(var.environment)
     Cost_Code   = module.globals.project_cost_code
     AppType     = "ECS"
-
-    # Tags required by auto-update
-    Name       = "cloudfront_g"
-    AutoUpdate = true
-    Protocol   = "http"
   }
 }
 
@@ -105,10 +100,5 @@ resource "aws_security_group" "public_alb_cf_regional" {
     Environment = upper(var.environment)
     Cost_Code   = module.globals.project_cost_code
     AppType     = "ECS"
-
-    # Tags required by auto-update
-    Name       = "cloudfront_r"
-    AutoUpdate = true
-    Protocol   = "http"
   }
 }

--- a/terraform/modules/load-balancer/main.tf
+++ b/terraform/modules/load-balancer/main.tf
@@ -6,7 +6,8 @@
 ##############################################################
 
 module "globals" {
-  source = "../globals"
+  source      = "../globals"
+  environment = var.environment
 }
 
 resource "aws_lb" "public_alb" {
@@ -17,12 +18,7 @@ resource "aws_lb" "public_alb" {
   security_groups    = [aws_security_group.public_alb_cf_global.id, aws_security_group.public_alb_cf_regional.id]
   #depends_on         = [aws_internet_gateway.scale]
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "LOADBALANCER"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "LOADBALANCER" })
 }
 
 resource "aws_security_group" "public_alb_cf_global" {
@@ -57,12 +53,7 @@ resource "aws_security_group" "public_alb_cf_global" {
     to_port     = 0
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "ECS"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "ECS" })
 }
 
 resource "aws_security_group" "public_alb_cf_regional" {
@@ -95,10 +86,6 @@ resource "aws_security_group" "public_alb_cf_regional" {
     to_port     = 0
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "ECS"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "ECS" })
+
 }

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -4,7 +4,8 @@
 # Memcached & Redis
 ##########################################################
 module "globals" {
-  source = "../globals"
+  source      = "../globals"
+  environment = var.environment
 }
 
 resource "aws_elasticache_subnet_group" "ec" {
@@ -21,12 +22,7 @@ resource "aws_elasticache_cluster" "memcached" {
   security_group_ids   = var.security_group_memcached_ids
   subnet_group_name    = aws_elasticache_subnet_group.ec.name
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "MEMCACHED"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "MEMCACHED" })
 }
 
 resource "aws_elasticache_cluster" "redis" {
@@ -39,10 +35,5 @@ resource "aws_elasticache_cluster" "redis" {
   security_group_ids   = var.security_group_redis_ids
   subnet_group_name    = aws_elasticache_subnet_group.ec.name
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "REDIS"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "REDIS" })
 }

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -1,16 +1,19 @@
-
 ##########################################################
 # Caches
 #
 # Memcached & Redis
 ##########################################################
+module "globals" {
+  source = "../globals"
+}
+
 resource "aws_elasticache_subnet_group" "ec" {
   name       = "tf-test-cache-subnet"
   subnet_ids = var.private_app_subnet_ids
 }
 
 resource "aws_elasticache_cluster" "memcached" {
-  cluster_id           = "memcached-spree"
+  cluster_id           = "scale-eu2-ec-spree-memcached"
   engine               = "memcached"
   node_type            = "cache.t3.medium"
   num_cache_nodes      = 2
@@ -27,7 +30,7 @@ resource "aws_elasticache_cluster" "memcached" {
 }
 
 resource "aws_elasticache_cluster" "redis" {
-  cluster_id           = "redis-spree"
+  cluster_id           = "scale-eu2-ec-spree-redis"
   engine               = "redis"
   node_type            = "cache.t2.medium"
   num_cache_nodes      = 1

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -17,6 +17,13 @@ resource "aws_elasticache_cluster" "memcached" {
   parameter_group_name = "default.memcached1.5"
   security_group_ids   = var.security_group_memcached_ids
   subnet_group_name    = aws_elasticache_subnet_group.ec.name
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "MEMCACHED"
+  }
 }
 
 resource "aws_elasticache_cluster" "redis" {
@@ -28,4 +35,11 @@ resource "aws_elasticache_cluster" "redis" {
   engine_version       = "5.0.6"
   security_group_ids   = var.security_group_redis_ids
   subnet_group_name    = aws_elasticache_subnet_group.ec.name
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "REDIS"
+  }
 }

--- a/terraform/modules/memcached/variables.tf
+++ b/terraform/modules/memcached/variables.tf
@@ -1,3 +1,7 @@
+variable "environment" {
+  type = string
+}
+
 variable "vpc_id" {
   type = string
 }

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -4,91 +4,57 @@
 # Buckets and initial objects
 ##########################################################
 module "globals" {
-  source = "../globals"
+  source      = "../globals"
+  environment = var.environment
 }
 
 resource "aws_s3_bucket" "static" {
   bucket        = "spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "S3"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket" "system" {
   bucket        = "system-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "S3"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket" "feed" {
   bucket        = "feed-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "S3"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket" "cnet" {
   bucket        = "cnet-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "S3"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket_object" "env-spree" {
-  bucket  = aws_s3_bucket.system.id
-  key     = "spree.env"
-  acl     = "private"
+  bucket = aws_s3_bucket.system.id
+  key    = "spree.env"
+  acl    = "private"
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "S3"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket_object" "env-client" {
-  bucket  = aws_s3_bucket.system.id
-  key     = "client.env"
-  acl     = "private"
+  bucket = aws_s3_bucket.system.id
+  key    = "client.env"
+  acl    = "private"
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "S3"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket" "product-import" {
   bucket        = "spree-${lower(var.environment)}-products-import"
   force_destroy = true
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "S3"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -6,36 +6,85 @@
 resource "aws_s3_bucket" "static" {
   bucket        = "spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "S3"
+  }
 }
 
 resource "aws_s3_bucket" "system" {
   bucket        = "system-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "S3"
+  }
 }
 
 resource "aws_s3_bucket" "feed" {
   bucket        = "feed-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "S3"
+  }
 }
 
 resource "aws_s3_bucket" "cnet" {
   bucket        = "cnet-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "S3"
+  }
 }
 
 resource "aws_s3_bucket_object" "env-spree" {
   bucket  = aws_s3_bucket.system.id
   key     = "spree.env"
   acl     = "private"
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "S3"
+  }
 }
 
 resource "aws_s3_bucket_object" "env-client" {
   bucket  = aws_s3_bucket.system.id
   key     = "client.env"
   acl     = "private"
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "S3"
+  }
 }
 
 resource "aws_s3_bucket" "product-import" {
   bucket        = "spree-${lower(var.environment)}-products-import"
   force_destroy = true
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "S3"
+  }
 }

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -3,6 +3,10 @@
 #
 # Buckets and initial objects
 ##########################################################
+module "globals" {
+  source = "../globals"
+}
+
 resource "aws_s3_bucket" "static" {
   bucket        = "spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true

--- a/terraform/modules/services/client/client.json.tpl
+++ b/terraform/modules/services/client/client.json.tpl
@@ -59,6 +59,10 @@
       {
         "name": "SPREE_IMAGE_HOST",
         "value": "${spree_image_host}"
+      },
+      {
+        "name": "SPREE_API_HOST",
+        "value": "${spree_api_host}"
       }
     ],
     "command": [

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -53,6 +53,10 @@ resource "aws_lb_listener" "port_80" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.target_group_8080.arn
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # TEMPORARY - REFACTOR - JUST MIMICS MANUAL CHANGES IN CONSOLE
@@ -134,12 +138,14 @@ resource "aws_ecs_service" "client" {
     container_port   = 8080
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "ECS"
-  }
+  # TODO: need to opt-in to new arn and resource id formats before can enable tags - need to understand this first
+  # https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/
+  #tags = {
+  #  Project     = module.globals.project_name
+  #  Environment = upper(var.environment)
+  #  Cost_Code   = module.globals.project_cost_code
+  #  AppType     = "ECS"
+  #}
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -5,7 +5,8 @@
 ##########################################################
 
 module "globals" {
-  source = "../../globals"
+  source      = "../../globals"
+  environment = var.environment
 }
 
 #######################################################################
@@ -34,12 +35,8 @@ resource "aws_lb_target_group" "target_group_8080" {
     path                = "/healthcheck"
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "LOADBALANCER"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "LOADBALANCER" })
+
 }
 
 resource "aws_lb_listener" "port_80" {
@@ -89,7 +86,7 @@ data "template_file" "app_client" {
   template = file("${path.module}/client.json.tpl")
 
   vars = {
-    app_image = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/bat-buyer-ui-staging:${var.ecr_image_id_client}"
+    app_image             = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/bat-buyer-ui-staging:${var.ecr_image_id_client}"
     app_port              = var.client_app_port
     fargate_cpu           = var.client_cpu
     fargate_memory        = var.client_memory
@@ -139,12 +136,7 @@ resource "aws_ecs_service" "client" {
 
   # TODO: need to opt-in to new arn and resource id formats before can enable tags - need to understand this first
   # https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/
-  #tags = {
-  #  Project     = module.globals.project_name
-  #  Environment = upper(var.environment)
-  #  Cost_Code   = module.globals.project_cost_code
-  #  AppType     = "ECS"
-  #}
+  #tags = merge(module.globals.project_resource_tags, {AppType = "ECS"})
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -133,6 +133,13 @@ resource "aws_ecs_service" "client" {
     container_name   = "client-app-task"
     container_port   = 8080
   }
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "ECS"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -89,8 +89,7 @@ data "template_file" "app_client" {
   template = file("${path.module}/client.json.tpl")
 
   vars = {
-    app_image = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/bat-buyer-ui-staging:latest"
-    //app_image             = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/agreements-service:hello-world-test-1"
+    app_image = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/bat-buyer-ui-staging:${var.ecr_image_id_client}"
     app_port              = var.client_app_port
     fargate_cpu           = var.client_cpu
     fargate_memory        = var.client_memory
@@ -103,7 +102,7 @@ data "template_file" "app_client" {
     basicauth_password    = var.basicauth_password
     basicauth_enabled     = var.basicauth_enabled
     rollbar_env           = var.rollbar_env
-    spree_image_host      = var.spree_image_host
+    spree_image_host      = "https://${var.spree_image_host}"
     env_file              = var.env_file
     client_session_secret = var.client_session_secret
   }

--- a/terraform/modules/services/client/variables.tf
+++ b/terraform/modules/services/client/variables.tf
@@ -91,6 +91,6 @@ variable "cloudfront_id" {
   type = string
 }
 
-#variable "lb_public_alb_listner_arn" {
-# type = string
-#}
+variable "ecr_image_id_client" {
+  type = string
+}

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -1,6 +1,7 @@
 
 module "globals" {
-  source = "../../globals"
+  source      = "../../globals"
+  environment = var.environment
 }
 
 data "template_file" "app_sidekiq" {
@@ -57,12 +58,7 @@ resource "aws_ecs_service" "sidekiq" {
 
   # TODO: need to opt-in to new arn and resource id formats before can enable tags - need to understand this first
   # https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/
-  #tags = {
-  #  Project     = module.globals.project_name
-  #  Environment = upper(var.environment)
-  #  Cost_Code   = module.globals.project_cost_code
-  #  AppType     = "ECS"
-  #}
+  #tags = merge(module.globals.project_resource_tags, {AppType = "ECS"})
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -7,8 +7,7 @@ data "template_file" "app_sidekiq" {
   template = file("${path.module}/sidekiq.json.tpl")
 
   vars = {
-    //app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/spree-service-staging:hello-world-test-4567"
-    app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/spree-service-staging:latest"
+    app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/spree-service-staging:${var.ecr_image_id_spree}"
     app_port                   = var.app_port
     fargate_cpu                = var.cpu
     fargate_memory             = var.memory
@@ -27,6 +26,9 @@ data "template_file" "app_sidekiq" {
     rollbar_env                = var.rollbar_env
     env_file                   = var.env_file
     redis_url                  = var.redis_url
+    elasticsearch_url          = var.elasticsearch_url
+    buyer_ui_url               = var.buyer_ui_url
+    app_domain                 = var.app_domain
   }
 }
 

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -53,12 +53,14 @@ resource "aws_ecs_service" "sidekiq" {
     subnets         = var.private_app_subnet_ids
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "ECS"
-  }
+  # TODO: need to opt-in to new arn and resource id formats before can enable tags - need to understand this first
+  # https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/
+  #tags = {
+  #  Project     = module.globals.project_name
+  #  Environment = upper(var.environment)
+  #  Cost_Code   = module.globals.project_cost_code
+  #  AppType     = "ECS"
+  #}
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -52,6 +52,13 @@ resource "aws_ecs_service" "sidekiq" {
     security_groups = var.security_groups
     subnets         = var.private_app_subnet_ids
   }
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "ECS"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/sidekiq/sidekiq.json.tpl
+++ b/terraform/modules/services/sidekiq/sidekiq.json.tpl
@@ -67,6 +67,18 @@
       {
         "name": "ROLLBAR_ENV",
         "value": "${rollbar_env}"
+      },
+      {
+        "name": "ELASTICSEARCH_URL",
+        "value": "${elasticsearch_url}"
+      },
+      {
+        "name": "APP_DOMAIN",
+        "value": "${app_domain}"
+      },
+      {
+        "name": "BUYER_UI_URL",
+        "value": "${buyer_ui_url}"
       }
     ],
     "command": [

--- a/terraform/modules/services/sidekiq/variables.tf
+++ b/terraform/modules/services/sidekiq/variables.tf
@@ -89,3 +89,19 @@ variable "redis_url" {
 variable "security_groups" {
   type = list(string)
 }
+
+variable "elasticsearch_url" {
+  type = string
+}
+
+variable "buyer_ui_url" {
+  type = string
+}
+
+variable "ecr_image_id_spree" {
+  type = string
+}
+
+variable "app_domain" {
+  type = string
+}

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -120,7 +120,7 @@ data "template_file" "app_client" {
   template = file("${path.module}/spree.json.tpl")
 
   vars = {
-    app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/spree-service-staging:latest"
+    app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/spree-service-staging:${var.ecr_image_id_spree}"
     app_port                   = var.app_port
     fargate_cpu                = var.cpu
     fargate_memory             = var.memory
@@ -140,6 +140,9 @@ data "template_file" "app_client" {
     env_file                   = var.env_file
     redis_url                  = var.redis_url
     memcached_endpoint         = var.memcached_endpoint
+    elasticsearch_url          = var.elasticsearch_url
+    buyer_ui_url               = var.buyer_ui_url
+    app_domain                 = var.app_domain
   }
 }
 

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -49,6 +49,10 @@ resource "aws_lb_listener" "port_80" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.target_group_4567.arn
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # TEMPORARY - REFACTOR - JUST MIMICS MANUAL CHANGES IN CONSOLE
@@ -168,12 +172,14 @@ resource "aws_ecs_service" "spree" {
     container_port   = var.app_port
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "ECS"
-  }
+  # TODO: need to opt-in to new arn and resource id formats before can enable tags - need to understand this first
+  # https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/
+  #tags = {
+  #  Project     = module.globals.project_name
+  #  Environment = upper(var.environment)
+  #  Cost_Code   = module.globals.project_cost_code
+  #  AppType     = "ECS"
+  #}
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -168,10 +168,11 @@ resource "aws_ecs_service" "spree" {
     container_port   = var.app_port
   }
 
-  load_balancer {
-    target_group_arn = aws_lb_target_group.target_group_4567_nlb.arn
-    container_name   = "spree-app-task"
-    container_port   = var.app_port
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "ECS"
   }
 }
 

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -1,6 +1,7 @@
 
 module "globals" {
-  source = "../../globals"
+  source      = "../../globals"
+  environment = var.environment
 }
 
 #######################################################################
@@ -30,12 +31,7 @@ resource "aws_lb_target_group" "target_group_4567" {
     path                = "/healthcheck"
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "LOADBALANCER"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "LOADBALANCER" })
 }
 
 resource "aws_lb_listener" "port_80" {
@@ -95,12 +91,8 @@ resource "aws_lb_target_group" "target_group_4567_nlb" {
     enabled = false
   }
 
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "LOADBALANCER"
-  }
+  tags = merge(module.globals.project_resource_tags, { AppType = "LOADBALANCER" })
+
 }
 
 resource "aws_lb_listener" "port_80_internal" {
@@ -177,12 +169,7 @@ resource "aws_ecs_service" "spree" {
 
   # TODO: need to opt-in to new arn and resource id formats before can enable tags - need to understand this first
   # https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/
-  #tags = {
-  #  Project     = module.globals.project_name
-  #  Environment = upper(var.environment)
-  #  Cost_Code   = module.globals.project_cost_code
-  #  AppType     = "ECS"
-  #}
+  #tags = merge(module.globals.project_resource_tags, {AppType = "ECS"})
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {

--- a/terraform/modules/services/spree/spree.json.tpl
+++ b/terraform/modules/services/spree/spree.json.tpl
@@ -71,6 +71,18 @@
       {
         "name": "ROLLBAR_ENV",
         "value": "${rollbar_env}"
+      },
+      {
+        "name": "ELASTICSEARCH_URL",
+        "value": "${elasticsearch_url}"
+      },
+      {
+        "name": "APP_DOMAIN",
+        "value": "${app_domain}"
+      },
+      {
+        "name": "BUYER_UI_URL",
+        "value": "${buyer_ui_url}"
       }
     ],
     "command": [

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -18,6 +18,10 @@ variable "lb_public_alb_arn" {
   type = string
 }
 
+variable "lb_public_alb_dns" {
+  type = string
+}
+
 variable "lb_private_nlb_arn" {
   type = string
 }
@@ -103,5 +107,21 @@ variable "security_groups" {
 }
 
 variable "cloudfront_id" {
+  type = string
+}
+
+variable "elasticsearch_url" {
+  type = string
+}
+
+variable "buyer_ui_url" {
+  type = string
+}
+
+variable "ecr_image_id_spree" {
+  type = string
+}
+
+variable "app_domain" {
   type = string
 }


### PR DESCRIPTION
This renames the main resources to align more with TechOps standards, and adds Tags where applicable

I've left the TODO on the Tags on the EC2 ECS services for now - need to revisit this at some point

I think (as discussed with Tom) - there is more refactoring coming up - so we need to revisit names and tags as we get into that - so this is just to grab some of the low hanging fruit as we know we have a re-provisioning of DEV/INT coming up
