### PR TITLE
SINF-83 - fix to value for SPREE_API_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check the README file for details of how to create the database.
 
 ```
 SESSION_COOKIE_SECRET={RANDOM_STRING? NOT SURE}
+DOCUMENTS_TERMS_AND_CONDITIONS_URL=https://purchasingplatform.crowncommercial.gov.uk/
 ```
 
 6. Create `spree.env` environment file

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -456,7 +456,6 @@ module "client" {
   client_cpu            = 256
   client_memory         = 512
   aws_region            = local.aws_region
-  spree_api_host        = data.aws_ssm_parameter.lb_private_dns.value
   rollbar_access_token  = data.aws_ssm_parameter.rollbar_access_token.value
   basicauth_username    = data.aws_ssm_parameter.basic_auth_username.value
   basicauth_password    = data.aws_ssm_parameter.basic_auth_password.value
@@ -466,6 +465,7 @@ module "client" {
   env_file              = module.s3.env_file_client
   cloudfront_id         = data.aws_ssm_parameter.cloudfront_id.value
   rollbar_env           = data.aws_ssm_parameter.rollbar_env.value
-  spree_image_host      = module.load_balancer_spree.lb_public_alb_dns
+  spree_api_host        = "http://${data.aws_ssm_parameter.lb_private_dns.value}"
+  spree_image_host      = "https://${module.load_balancer_spree.lb_public_alb_dns}"
   ecr_image_id_client   = var.ecr_image_id_client
 }

--- a/terraform/modules/services/client/client.json.tpl
+++ b/terraform/modules/services/client/client.json.tpl
@@ -46,7 +46,7 @@
       },
       {
         "name": "SPREE_API_HOST",
-        "value": "http://${spree_api_host}"
+        "value": "${spree_api_host}"
       },
       {
         "name": "SESSION_COOKIE_SECRET",

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -94,12 +94,12 @@ data "template_file" "app_client" {
     name                  = "client-app-task"
     api_host              = var.client_app_host
     spree_api_host        = var.spree_api_host
+    spree_image_host      = var.spree_image_host
     rollbar_access_token  = var.rollbar_access_token
     basicauth_username    = var.basicauth_username
     basicauth_password    = var.basicauth_password
     basicauth_enabled     = var.basicauth_enabled
     rollbar_env           = var.rollbar_env
-    spree_image_host      = "https://${var.spree_image_host}"
     env_file              = var.env_file
     client_session_secret = var.client_session_secret
   }


### PR DESCRIPTION
Fix to the issue of logging in - the problem seemed to be that the `SPREE_API_HOST` env variable was missing the `http://` prefix. I made some tweaks, deployed to SBX1 and it works.

I've just reviewed the PR below - and can't see why it shouldn't have had the 'https://' before - because it looks like nothing has actually changed when you look at the PR. I've just double checked on SBX2 though - and it is the same as SBX1 was - i.e. no 'http://' prefix. 🤷‍♂️ I just did a TF apply with this new code - and it kicked off a new task, gracefully retired the old task and just worked..

(couple of other tweaks - related to image host and also a new param I noticed that had been added in client.env on SBX6)