### PR TITLE
SINF-7 - move rollbar_env to a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Check the README file for details of how to create the database.
   /bar/{env}-basic-auth-enabled
   /bat/{env}-session-cookie-secret
   /bat/{env}-products-import-bucket
-  /bat/{env}-rollbar-env
 ```
 
 4. Run `terraform apply`

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -30,6 +30,7 @@ module "deploy" {
   source              = "../../modules/configs/deploy-all"
   aws_account_id      = data.aws_ssm_parameter.aws_account_id.value
   environment         = local.environment
+  rollbar_env         = local.environment
   ecr_image_id_spree  = "latest"
   ecr_image_id_client = "latest"
 }

--- a/terraform/environments/int/main.tf
+++ b/terraform/environments/int/main.tf
@@ -30,4 +30,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  rollbar_env    = local.environment
 }

--- a/terraform/environments/sbx1/main.tf
+++ b/terraform/environments/sbx1/main.tf
@@ -30,4 +30,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  rollbar_env    = local.environment
 }

--- a/terraform/environments/sbx2/main.tf
+++ b/terraform/environments/sbx2/main.tf
@@ -30,4 +30,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  rollbar_env    = local.environment
 }

--- a/terraform/environments/sbx4/main.tf
+++ b/terraform/environments/sbx4/main.tf
@@ -30,4 +30,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  rollbar_env    = local.environment
 }

--- a/terraform/environments/sbx6/main.tf
+++ b/terraform/environments/sbx6/main.tf
@@ -30,4 +30,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  rollbar_env    = local.environment
 }

--- a/terraform/environments/tst/main.tf
+++ b/terraform/environments/tst/main.tf
@@ -26,4 +26,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  rollbar_env    = local.environment
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -84,10 +84,6 @@ data "aws_ssm_parameter" "products_import_bucket" {
   name = "/bat/${lower(var.environment)}-products-import-bucket"
 }
 
-data "aws_ssm_parameter" "rollbar_env" {
-  name = "/bat/${lower(var.environment)}-rollbar-env"
-}
-
 data "aws_ssm_parameter" "spree_db_username" {
   name            = "/bat/${lower(var.environment)}-spree-db-app-username"
   with_decryption = true
@@ -392,7 +388,7 @@ module "spree" {
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
   basicauth_enabled      = data.aws_ssm_parameter.basic_auth_enabled.value
   products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
-  rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
+  rollbar_env            = var.rollbar_env
   redis_url              = module.memcached.redis_url
   memcached_endpoint     = module.memcached.memcached_endpoint
   security_groups        = [aws_security_group.spree.id]
@@ -429,7 +425,7 @@ module "sidekiq" {
   basicauth_password     = data.aws_ssm_parameter.basic_auth_password.value
   basicauth_enabled      = data.aws_ssm_parameter.basic_auth_enabled.value
   products_import_bucket = data.aws_ssm_parameter.products_import_bucket.value
-  rollbar_env            = data.aws_ssm_parameter.rollbar_env.value
+  rollbar_env            = var.rollbar_env
   redis_url              = module.memcached.redis_url
   security_groups        = [aws_security_group.spree.id]
   env_file               = module.s3.env_file_spree
@@ -464,8 +460,8 @@ module "client" {
   security_groups       = [aws_security_group.client.id]
   env_file              = module.s3.env_file_client
   cloudfront_id         = data.aws_ssm_parameter.cloudfront_id.value
-  rollbar_env           = data.aws_ssm_parameter.rollbar_env.value
   spree_api_host        = "http://${data.aws_ssm_parameter.lb_private_dns.value}"
   spree_image_host      = "https://${module.load_balancer_spree.lb_public_alb_dns}"
+  rollbar_env           = var.rollbar_env
   ecr_image_id_client   = var.ecr_image_id_client
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -30,3 +30,7 @@ variable "ecr_image_id_client" {
   type    = string
   default = "latest"
 }
+
+variable "rollbar_env" {
+  type    = string
+}


### PR DESCRIPTION
Changed rollbar_env from an SSM param to a variable - why?:

1. Removes the need to manually set SSM param in each environment
2. Allows override of empty/null in PRD (an SSM param cannot take an empty string - so would have to use some flag with checks) (PRD should have no value set for rollbar_env)

Couldn't see a more elegant way to do this (I had hoped that somehow could default the `rollbar_env` variable to the `environment` variable - but not that I could see while still allowing an override)