### PR TITLE
update readme with the product catalogue directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,16 @@ After importing CNET data you will need to reindex Elastic search again
 ```
 bundle exec rails searchkick:reindex:all
 ```
+
+Set up product catalogue directory structure
+
+Go to the following S3 bucket spree-{env}-product-import
+
+- create folder called `imports`
+- inside the `imports` folder create the following folders
+```
+  - done
+  - error
+  - new
+  - processings
+```


### PR DESCRIPTION
Update Readme to include the setup of product catalogue directory structure for importing of product structure.

The reason you can do this in terraform is that S3 doesn't support folders. An S3 objects can have prefix names with slashes that look like folders, but that's just part of the object name. So there's no way to create a folder in terraform or anything else, because there's no such thing as a folder in S3.