### PR TITLE
SINF-211 - updated image root to use the new R53 hosted zone (& cert)

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -485,7 +485,7 @@ module "client" {
   env_file               = module.s3.env_file_client
   cloudfront_id          = data.aws_ssm_parameter.cloudfront_id.value
   spree_api_host         = "http://${data.aws_ssm_parameter.lb_private_dns.value}"
-  spree_image_host       = "https://${data.aws_ssm_parameter.hosted_zone_name_alb_bat_client.value}"
+  spree_image_host       = "https://${data.aws_ssm_parameter.hosted_zone_name_alb_bat_backend.value}"
   rollbar_env            = var.rollbar_env
   ecr_image_id_client    = var.ecr_image_id_client
   papertrail_hostname    = data.aws_ssm_parameter.papertrail_hostname.value

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -485,7 +485,7 @@ module "client" {
   env_file               = module.s3.env_file_client
   cloudfront_id          = data.aws_ssm_parameter.cloudfront_id.value
   spree_api_host         = "http://${data.aws_ssm_parameter.lb_private_dns.value}"
-  spree_image_host       = "https://${module.load_balancer_spree.lb_public_alb_dns}"
+  spree_image_host       = "https://${data.aws_ssm_parameter.hosted_zone_name_alb_bat_client.value}"
   rollbar_env            = var.rollbar_env
   ecr_image_id_client    = var.ecr_image_id_client
   papertrail_hostname    = data.aws_ssm_parameter.papertrail_hostname.value


### PR DESCRIPTION
TechOps added NS records for BaT last night - seem to be propagated for SBX1 & DEV this morning.

Realised image roots need updating to use the new domain.

Tried a cheeky deploy to DEV - seems to work

Available now on
https://dev.scale-bat-client.alb.crowncommercial.gov.uk