### PR TITLE
create directory structure for cnet data

### DIFF
--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -58,3 +58,50 @@ resource "aws_s3_bucket" "product-import" {
 
   tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
+
+resource "aws_s3_bucket_object" "nightly_updates" {
+  bucket = aws_s3_bucket.cnet.id
+  key    = "nightly_updates/"
+  acl    = "private"
+  source = "/dev/null"
+
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
+}
+
+resource "aws_s3_bucket_object" "nightly_updates_new" {
+  bucket = aws_s3_bucket.cnet.id
+  key    = "nightly_updates/new/"
+  acl    = "private"
+  source = "/dev/null"
+
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
+}
+
+resource "aws_s3_bucket_object" "nightly_updates_error" {
+  bucket = aws_s3_bucket.cnet.id
+  key    = "nightly_updates/error/"
+  acl    = "private"
+  source = "/dev/null"
+
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
+}
+
+resource "aws_s3_bucket_object" "nightly_updates_processing" {
+  bucket = aws_s3_bucket.cnet.id
+  key    = "nightly_updates/processing/"
+  acl    = "private"
+  source = "/dev/null"
+
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
+}
+
+resource "aws_s3_bucket_object" "nightly_updates_done" {
+  bucket = aws_s3_bucket.cnet.id
+  key    = "nightly_updates/done/"
+  acl    = "private"
+  source = "/dev/null"
+
+  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
+}
+
+


### PR DESCRIPTION
Add a directory structure for cnet data for nightly updates

    cnet-spree-dev-staging (s3 bucket)
    |── nightly_updates/                                     # nightly updates folder
    │       ├── new/                                         # folder nightly updates are place
    │       ├──  processing/                                 # file are move to this folder during processing
    │       ├──  error/                                      # files with errors are moved to this folder
    │       ├──  done/                                       # completed updates are moved to this folder

This PR is based on this forum [post](https://www.edureka.co/community/78246/how-to-create-a-folder-inside-s3-bucket-using-terraform-code)

