### PR TITLE
SINF-256 - set `vpc_zone_identifier to public web for spree & sidekiq

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -375,7 +375,7 @@ module "ecs_client" {
 module "ecs_spree" {
   source               = "../../ecs"
   environment          = var.environment
-  subnet_ids           = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
+  subnet_ids           = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
   security_group_ids   = [aws_security_group.client.id]
   ec2_instance_type    = var.spree_ec2_instance_type
   resource_name_suffix = "SPREE"
@@ -384,7 +384,7 @@ module "ecs_spree" {
 module "ecs_sidekiq" {
   source               = "../../ecs"
   environment          = var.environment
-  subnet_ids           = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
+  subnet_ids           = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
   security_group_ids   = [aws_security_group.client.id]
   ec2_instance_type    = var.sidekiq_ec2_instance_type
   resource_name_suffix = "SIDEKIQ"


### PR DESCRIPTION
Noticed I had set the `vpc_zone_identifier` on autoscaling group to the private app subnet for the new spree/spark components - think this needs to be the public web subnets (as it was when all 3 were combined)