### PR TITLE
Feature/sinf 256 elasticache multi az

### DIFF
--- a/terraform/environments/sbx1/main.tf
+++ b/terraform/environments/sbx1/main.tf
@@ -36,7 +36,7 @@ module "deploy" {
   client_ec2_instance_type  = "t2.large"
   spree_cpu                 = 2048
   spree_memory              = 7168 #8192
-  spree_ec2_instance_type   = "t2.large" 
+  spree_ec2_instance_type   = "t2.large"
   sidekiq_cpu               = 2048
   sidekiq_memory            = 7168 #8192
   sidekiq_ec2_instance_type = "t2.large"

--- a/terraform/environments/sbx2/main.tf
+++ b/terraform/environments/sbx2/main.tf
@@ -27,8 +27,17 @@ data "aws_ssm_parameter" "aws_account_id" {
 }
 
 module "deploy" {
-  source         = "../../modules/configs/deploy-all"
-  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
-  environment    = local.environment
-  rollbar_env    = local.environment
+  source                    = "../../modules/configs/deploy-all"
+  aws_account_id            = data.aws_ssm_parameter.aws_account_id.value
+  environment               = local.environment
+  rollbar_env               = local.environment
+  client_cpu                = 2048
+  client_memory             = 3548 #4096
+  client_ec2_instance_type  = "t2.medium"
+  spree_cpu                 = 2048
+  spree_memory              = 7168 #8192
+  spree_ec2_instance_type   = "t2.large"
+  sidekiq_cpu               = 2048
+  sidekiq_memory            = 7168 #8192
+  sidekiq_ec2_instance_type = "t2.large"
 }

--- a/terraform/environments/sbx8/main.tf
+++ b/terraform/environments/sbx8/main.tf
@@ -34,7 +34,7 @@ module "deploy" {
   ecr_image_id_spree        = "latest"
   ecr_image_id_client       = "latest"
   client_cpu                = 4096
-  client_memory             = 8192 #t2.xlarge - 16GB available
+  client_memory             = 8192        #t2.xlarge - 16GB available
   client_ec2_instance_type  = "t2.xlarge" # NB: Som's initial design was 4/8, Ravi approved use of t2.xlarge as nearest instance size
   spree_cpu                 = 4096
   spree_memory              = 15360 #16GB available - save 1GB for the instance (or increase to t2.xlarge)
@@ -44,4 +44,5 @@ module "deploy" {
   sidekiq_ec2_instance_type = "t2.xlarge"
   memcached_node_type       = "cache.m4.large"
   redis_node_type           = "cache.m4.large"
+  az_names                  = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -361,6 +361,7 @@ module "memcached" {
   security_group_redis_ids     = [aws_security_group.redis.id]
   memcached_node_type          = var.memcached_node_type
   redis_node_type              = var.redis_node_type
+  az_names                     = var.az_names
 }
 
 module "ecs_client" {

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -354,6 +354,7 @@ module "s3" {
 
 module "memcached" {
   source                       = "../../memcached"
+  aws_account_id               = var.aws_account_id
   environment                  = var.environment
   vpc_id                       = data.aws_ssm_parameter.vpc_id.value
   private_app_subnet_ids       = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -101,3 +101,8 @@ variable "deployment_minimum_healthy_percent" {
   type    = number
   default = 50
 }
+
+variable "az_names" {
+  type    = list(string)
+  default = ["eu-west-2a", "eu-west-2b"]
+}

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -23,7 +23,7 @@ resource "aws_elasticache_cluster" "memcached" {
   engine_version               = "1.6.6"
   node_type                    = var.memcached_node_type
   num_cache_nodes              = length(var.private_app_subnet_ids)
-  parameter_group_name         = "default.memcached1.5"
+  parameter_group_name         = "default.memcached1.6"
   security_group_ids           = var.security_group_memcached_ids
   subnet_group_name            = aws_elasticache_subnet_group.ec.name
   az_mode                      = "cross-az"

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -27,24 +27,27 @@ resource "aws_elasticache_cluster" "memcached" {
   security_group_ids           = var.security_group_memcached_ids
   subnet_group_name            = aws_elasticache_subnet_group.ec.name
   az_mode                      = "cross-az"
-  preferred_availability_zones = data.aws_availability_zones.available.names
+  preferred_availability_zones = var.az_names
 
   tags = merge(module.globals.project_resource_tags, { AppType = "MEMCACHED" })
 }
 
 resource "aws_elasticache_replication_group" "redis" {
   automatic_failover_enabled    = true
+  availability_zones            = var.az_names
   replication_group_id          = "scale-eu2-ec-spree-redis"
   replication_group_description = "Managed by Terraform"
   node_type                     = var.redis_node_type
+  number_cache_clusters         = length(var.private_app_subnet_ids)
+  parameter_group_name          = "default.redis6.x"
   port                          = 6379
   engine_version                = "6.x"
   security_group_ids            = var.security_group_redis_ids
   subnet_group_name             = aws_elasticache_subnet_group.ec.name
 
-  cluster_mode {
-    replicas_per_node_group = 1
-    num_node_groups         = length(var.private_app_subnet_ids)
+  # Without this it complains if you re'apply' with no changes
+  lifecycle {
+    ignore_changes = [engine_version]
   }
 
   tags = merge(module.globals.project_resource_tags, { AppType = "REDIS" })

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -8,33 +8,44 @@ module "globals" {
   environment = var.environment
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elasticache_subnet_group" "ec" {
   name       = "tf-test-cache-subnet"
   subnet_ids = var.private_app_subnet_ids
 }
 
 resource "aws_elasticache_cluster" "memcached" {
-  cluster_id           = "scale-eu2-ec-spree-memcached"
-  engine               = "memcached"
-  engine_version       = "1.5.16"
-  node_type            = var.memcached_node_type
-  num_cache_nodes      = 2
-  parameter_group_name = "default.memcached1.5"
-  security_group_ids   = var.security_group_memcached_ids
-  subnet_group_name    = aws_elasticache_subnet_group.ec.name
+  cluster_id                   = "scale-eu2-ec-spree-memcached"
+  engine                       = "memcached"
+  engine_version               = "1.6.6"
+  node_type                    = var.memcached_node_type
+  num_cache_nodes              = length(var.private_app_subnet_ids)
+  parameter_group_name         = "default.memcached1.5"
+  security_group_ids           = var.security_group_memcached_ids
+  subnet_group_name            = aws_elasticache_subnet_group.ec.name
+  az_mode                      = "cross-az"
+  preferred_availability_zones = data.aws_availability_zones.available.names
 
   tags = merge(module.globals.project_resource_tags, { AppType = "MEMCACHED" })
 }
 
-resource "aws_elasticache_cluster" "redis" {
-  cluster_id           = "scale-eu2-ec-spree-redis"
-  engine               = "redis"
-  node_type            = var.redis_node_type
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
-  engine_version       = "5.0.6"
-  security_group_ids   = var.security_group_redis_ids
-  subnet_group_name    = aws_elasticache_subnet_group.ec.name
+resource "aws_elasticache_replication_group" "redis" {
+  automatic_failover_enabled    = true
+  replication_group_id          = "scale-eu2-ec-spree-redis"
+  replication_group_description = "Managed by Terraform"
+  node_type                     = var.redis_node_type
+  port                          = 6379
+  engine_version                = "6.x"
+  security_group_ids            = var.security_group_redis_ids
+  subnet_group_name             = aws_elasticache_subnet_group.ec.name
+
+  cluster_mode {
+    replicas_per_node_group = 1
+    num_node_groups         = length(var.private_app_subnet_ids)
+  }
 
   tags = merge(module.globals.project_resource_tags, { AppType = "REDIS" })
 }

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_url" {
-    value = "redis://${aws_elasticache_replication_group.redis.configuration_endpoint_address}"
+    value = "redis://${aws_elasticache_replication_group.redis.configuration_endpoint_address}:6379"
 }
 
 output "memcached_endpoint" {

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_url" {
-    value = "redis://${aws_elasticache_replication_group.redis.configuration_endpoint_address}:6379"
+    value = "redis://${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379"
 }
 
 output "memcached_endpoint" {

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_url" {
-    value = "redis://${aws_elasticache_cluster.redis.cache_nodes.0.address}"
+    value = "redis://${aws_elasticache_replication_group.redis.configuration_endpoint_address}"
 }
 
 output "memcached_endpoint" {

--- a/terraform/modules/memcached/variables.tf
+++ b/terraform/modules/memcached/variables.tf
@@ -25,3 +25,7 @@ variable "memcached_node_type" {
 variable "redis_node_type" {
   type = string
 }
+
+variable "az_names" {
+  type = list(string)
+}

--- a/terraform/modules/memcached/variables.tf
+++ b/terraform/modules/memcached/variables.tf
@@ -1,3 +1,7 @@
+variable "aws_account_id" {
+  type = string
+}
+
 variable "environment" {
   type = string
 }


### PR DESCRIPTION
Think it will need 2 APP subnets configured as a minimum.

The previous commit had Redis configured in cluster mode, which span up with MultiAZ=true. However, there was an error in Sidekiq that googling suggested might need a tweak to the client calling code to work with cluster.

The current commit has replaced that with non-clustered multi-node version, but it doesn't seem to set MultiAZ=true by default. Still looking into that - but you want to have look round the PR thought I'd make available now