### PR TITLE
Add new lograge-enabled,sendgrid-api-key and mail-from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Check the README file for details of how to create the database.
   /bat/{env}-logit-remote-port
   /bat/{env}-suppliers-sftp-bucket
   /bat/{env}-documents-terms-and-conditions-url
+  /bat/{env}-lograge-enabled
+  /bat/{env}-sendgrid-api-key
+  /bat/{env}-mail-from
 ```
 
 4. Run `terraform apply`

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -122,6 +122,18 @@ data "aws_ssm_parameter" "documents_terms_and_conditions_url" {
   name = "/bat/${lower(var.environment)}-documents-terms-and-conditions-url"
 }
 
+data "aws_ssm_parameter" "lograge_enabled" {
+  name = "/bat/${lower(var.environment)}-lograge-enabled"
+}
+
+data "aws_ssm_parameter" "sendgrid_api_key" {
+  name = "/bat/${lower(var.environment)}-sendgrid-api-key"
+}
+
+data "aws_ssm_parameter" "mail_from" {
+  name = "/bat/${lower(var.environment)}-mail-from"
+}
+
 ######################################
 # CIDR ranges for whitelisting
 ######################################
@@ -452,6 +464,9 @@ module "spree" {
   suppliers_sftp_bucket              = data.aws_ssm_parameter.suppliers_sftp_bucket.value
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  lograge_enabled                    = data.aws_ssm_parameter.lograge_enabled.value
+  sendgrid_api_key                   = data.aws_ssm_parameter.sendgrid_api_key.value
+  mail_from                          = data.aws_ssm_parameter.mail_from.value
 }
 
 ######################################
@@ -492,6 +507,10 @@ module "sidekiq" {
   suppliers_sftp_bucket              = data.aws_ssm_parameter.suppliers_sftp_bucket.value
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  lograge_enabled                    = data.aws_ssm_parameter.lograge_enabled.value
+  sendgrid_api_key                   = data.aws_ssm_parameter.sendgrid_api_key.value
+  mail_from                          = data.aws_ssm_parameter.mail_from.value
+
 }
 
 ######################################

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -33,6 +33,10 @@ data "template_file" "app_sidekiq" {
     logit_hostname             = var.logit_hostname
     logit_remote_port          = var.logit_remote_port
     suppliers_sftp_bucket      = var.suppliers_sftp_bucket
+    lograge_enabled            = var.lograge_enabled
+    sendgrid_api_key           = var.sendgrid_api_key
+    mail_from                  = var.mail_from
+
   }
 }
 

--- a/terraform/modules/services/sidekiq/variables.tf
+++ b/terraform/modules/services/sidekiq/variables.tf
@@ -125,3 +125,15 @@ variable "deployment_maximum_percent" {
 variable "deployment_minimum_healthy_percent" {
   type = number
 }
+
+variable "lograge_enabled" {
+  type = string
+}
+
+variable "sendgrid_api_key" {
+  type = string
+}
+
+variable "mail_from" {
+  type = string
+}

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -109,6 +109,9 @@ data "template_file" "app_client" {
     logit_hostname             = var.logit_hostname
     logit_remote_port          = var.logit_remote_port
     suppliers_sftp_bucket      = var.suppliers_sftp_bucket
+    lograge_enabled            = var.lograge_enabled
+    sendgrid_api_key           = var.sendgrid_api_key
+    mail_from                  = var.mail_from
   }
 }
 

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -149,3 +149,15 @@ variable "deployment_maximum_percent" {
 variable "deployment_minimum_healthy_percent" {
   type = number
 }
+
+variable "lograge_enabled" {
+  type = string
+}
+
+variable "sendgrid_api_key" {
+  type = string
+}
+
+variable "mail_from" {
+  type = string
+}


### PR DESCRIPTION
Add new ENV variables

- **lograge-enabled:**  Lograge is an attempt to bring sanity to Rails' noisy and unusable, unparsable and, in the context of running multiple processes and servers, unreadable default logging output.  
- **sendgrid-api-key**  Sendgrid will stop using [Basic Authentication with Username and Password on 13th Jan](https://sendgrid.com/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys/#upgrade-to-api-keys-for-your-smtp-integration)
- **mail-from**  -  is from email address which send grid uses to 