### PR TITLE
Add S3 virus scan service

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -44,4 +44,10 @@ module "deploy" {
   sidekiq_ec2_instance_type = "t2.xlarge"
   memcached_node_type       = "cache.t3.medium"
   redis_node_type           = "cache.t3.medium"
+
+  # default values for s3-virus-scan-service subject to change based on testing on DEV
+  ecr_image_id_s3_virus_scan      = "latest"
+  s3_virus_scan_cpu               = 1024
+  s3_virus_scan_memory            = 2048
+  s3_virus_scan_ec2_instance_type = "t2.medium"
 }

--- a/terraform/environments/int/main.tf
+++ b/terraform/environments/int/main.tf
@@ -42,4 +42,10 @@ module "deploy" {
   sidekiq_ec2_instance_type = "t2.xlarge"
   memcached_node_type       = "cache.t3.medium"
   redis_node_type           = "cache.t3.medium"
+
+  # default values for s3-virus-scan-service subject to change based on testing on DEV
+  ecr_image_id_s3_virus_scan      = "latest"
+  s3_virus_scan_cpu               = 1024
+  s3_virus_scan_memory            = 2048
+  s3_virus_scan_ec2_instance_type = "t2.medium"
 }

--- a/terraform/environments/sbx2/main.tf
+++ b/terraform/environments/sbx2/main.tf
@@ -40,4 +40,9 @@ module "deploy" {
   sidekiq_cpu               = 2048
   sidekiq_memory            = 7168 #8192
   sidekiq_ec2_instance_type = "t2.large"
+
+  # Made these small for SBX environments (what should default be?)
+  s3_virus_scan_cpu               = 1024
+  s3_virus_scan_memory            = 1536
+  s3_virus_scan_ec2_instance_type = "t2.small"
 }

--- a/terraform/environments/sbx8/main.tf
+++ b/terraform/environments/sbx8/main.tf
@@ -45,4 +45,10 @@ module "deploy" {
   memcached_node_type       = "cache.m4.large"
   redis_node_type           = "cache.m4.large"
   az_names                  = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
+
+  # default values for s3-virus-scan-service subject to change based on testing on DEV
+  ecr_image_id_s3_virus_scan      = "latest"
+  s3_virus_scan_cpu               = 1024
+  s3_virus_scan_memory            = 2048
+  s3_virus_scan_ec2_instance_type = "t2.medium"
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -260,6 +260,25 @@ resource "aws_security_group_rule" "client-allow-outgoing" {
   security_group_id = aws_security_group.client.id
   cidr_blocks       = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "s3-virus-scan-allow-https" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.s3-virus-scan.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "s3-virus-scan-allow-outgoing" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.s3-virus-scan.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group" "rds" {
   vpc_id      = data.aws_ssm_parameter.vpc_id.value
   name        = "rds-spree-${lower(var.stage)}"
@@ -404,6 +423,15 @@ module "ecs_sidekiq" {
   resource_name_suffix = "SIDEKIQ"
 }
 
+module "ecs_s3_virus_scan" {
+  source               = "../../ecs"
+  environment          = var.environment
+  subnet_ids           = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
+  security_group_ids   = [aws_security_group.client.id]
+  ec2_instance_type    = var.s3_virus_scan_ec2_instance_type
+  resource_name_suffix = "S3_VIRUS_SCAN"
+}
+
 module "load_balancer_spree" {
   source                = "../../load-balancer"
   environment           = var.environment
@@ -421,6 +449,18 @@ module "load_balancer_client" {
   public_web_subnet_ids = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
   hosted_zone_name      = data.aws_ssm_parameter.hosted_zone_name_alb_bat_client.value
 }
+
+# I am not sure if this app S3_VIRUS_SCAN app needs a load_balancer_s3_virus_scan
+
+module "load_balancer_s3_virus_scan" {
+  source                = "../../load-balancer"
+  environment           = var.environment
+  vpc_id                = data.aws_ssm_parameter.vpc_id.value
+  lb_suffix             = "client"
+  public_web_subnet_ids = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
+  hosted_zone_name      = data.aws_ssm_parameter.hosted_zone_name_alb_bat_s3_virus_scan.value
+}
+
 
 ######################################
 # Spree Service
@@ -550,4 +590,22 @@ module "client" {
   documents_terms_and_conditions_url = data.aws_ssm_parameter.documents_terms_and_conditions_url.value
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+}
+
+######################################
+# S3 Virus scan Service
+######################################
+
+module "s3_virus_scan" {
+  source                             = "../../services/s3-virus-scan"
+  environment                        = var.environment
+  vpc_id                             = data.aws_ssm_parameter.vpc_id.value
+  ecs_cluster_id                     = module.ecs_s3_virus_scan.ecs_cluster_id
+  private_app_subnet_ids             = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
+  execution_role_arn                 = aws_iam_role.ecs_task_execution_role.arn
+  app_port                           = "4567"
+  cpu                                = var.s3_virus_scan_cpu
+  memory                             = var.s3_virus_scan_memory
+  ecr_image_id_s3_virus_scan         = var.ecr_image_id_s3_virus_scan
+  aws_region                         = local.aws_region
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -114,6 +114,10 @@ data "aws_ssm_parameter" "hosted_zone_name_alb_bat_backend" {
   name = "/bat/${lower(var.environment)}-hosted-zone-name-alb-bat-backend"
 }
 
+data "aws_ssm_parameter" "hosted_zone_name_alb_bat_s3_virus_scan" {
+  name = "/bat/${lower(var.environment)}-hosted-zone-name-alb-bat-s3-virus-scan"
+}
+
 data "aws_ssm_parameter" "suppliers_sftp_bucket" {
   name = "/bat/${lower(var.environment)}-suppliers-sftp-bucket"
 }
@@ -259,6 +263,12 @@ resource "aws_security_group_rule" "client-allow-outgoing" {
   protocol          = "-1"
   security_group_id = aws_security_group.client.id
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "s3-virus-scan" {
+  vpc_id      = data.aws_ssm_parameter.vpc_id.value
+  name        = "app-s3-virus-scan-${lower(var.stage)}"
+  description = "Allow inbound db traffic"
 }
 
 resource "aws_security_group_rule" "s3-virus-scan-allow-https" {
@@ -608,4 +618,7 @@ module "s3_virus_scan" {
   memory                             = var.s3_virus_scan_memory
   ecr_image_id_s3_virus_scan         = var.ecr_image_id_s3_virus_scan
   aws_region                         = local.aws_region
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  security_groups                    = [aws_security_group.s3-virus-scan.id]
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -31,6 +31,16 @@ variable "ecr_image_id_client" {
   default = "latest"
 }
 
+variable "ecr_image_id_s3_virus_scan" {
+  type    = string
+  default = "latest"
+}
+
+variable "ecr_image_id_s3_virus_scan" {
+  type    = string
+  default = "latest"
+}
+
 variable "rollbar_env" {
   type = string
 }
@@ -65,19 +75,35 @@ variable "sidekiq_memory" {
   default = 8192
 }
 
+variable "s3_virus_scan_cpu" {
+  type    = number
+  default = 4096
+}
+
+variable "s3_virus_scan_memory" {
+  type    = number
+  default = 8192
+}
+
 variable "client_ec2_instance_type" {
   type    = string
   default = "t2.medium"
 }
 
-# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now) 
+# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now)
 variable "spree_ec2_instance_type" {
   type    = string
   default = "t2.xlarge"
 }
 
-# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now) 
+# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now)
 variable "sidekiq_ec2_instance_type" {
+  type    = string
+  default = "t2.xlarge"
+}
+
+# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now)
+variable "s3_virus_scan_ec2_instance_type" {
   type    = string
   default = "t2.xlarge"
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -36,11 +36,6 @@ variable "ecr_image_id_s3_virus_scan" {
   default = "latest"
 }
 
-variable "ecr_image_id_s3_virus_scan" {
-  type    = string
-  default = "latest"
-}
-
 variable "rollbar_env" {
   type = string
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -70,11 +70,13 @@ variable "sidekiq_memory" {
   default = 8192
 }
 
+# TODO: Has this been specified?
 variable "s3_virus_scan_cpu" {
   type    = number
   default = 4096
 }
 
+# TODO: Has this been specified?
 variable "s3_virus_scan_memory" {
   type    = number
   default = 8192
@@ -97,7 +99,7 @@ variable "sidekiq_ec2_instance_type" {
   default = "t2.xlarge"
 }
 
-# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now)
+# TODO: Has this been specified?
 variable "s3_virus_scan_ec2_instance_type" {
   type    = string
   default = "t2.xlarge"

--- a/terraform/modules/services/s3-virus-scan/ecs.tf
+++ b/terraform/modules/services/s3-virus-scan/ecs.tf
@@ -7,7 +7,7 @@ data "template_file" "app_s3_virus_scan" {
   template = file("${path.module}/s3_virus_scan.json.tpl")
 
   vars = {
-    app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/s3-virus-scan:${var.ecr_image_id_spree}"
+    app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/s3-virus-scan:${var.ecr_image_id_s3_virus_scan}"
     app_port                   = var.app_port
     cpu                        = var.cpu
     memory                     = var.memory

--- a/terraform/modules/services/s3-virus-scan/ecs.tf
+++ b/terraform/modules/services/s3-virus-scan/ecs.tf
@@ -16,7 +16,6 @@ data "template_file" "app_s3_virus_scan" {
   }
 }
 
-
 resource "aws_ecs_task_definition" "app_s3_virus_scan" {
   family                   = "s3-virus-scan-task"
   execution_role_arn       = var.execution_role_arn
@@ -28,9 +27,9 @@ resource "aws_ecs_task_definition" "app_s3_virus_scan" {
 }
 
 resource "aws_ecs_service" "s3_virus_scan" {
-  name                               = "s3_virus_scan-service"
+  name                               = "s3-virus-scan-service"
   cluster                            = var.ecs_cluster_id
-  task_definition                    = aws_ecs_task_definition.s3_virus_scan.arn
+  task_definition                    = aws_ecs_task_definition.app_s3_virus_scan.arn
   desired_count                      = length(var.private_app_subnet_ids)
   launch_type                        = "EC2"
   deployment_maximum_percent         = var.deployment_maximum_percent

--- a/terraform/modules/services/s3-virus-scan/ecs.tf
+++ b/terraform/modules/services/s3-virus-scan/ecs.tf
@@ -1,0 +1,48 @@
+module "globals" {
+  source      = "../../globals"
+  environment = var.environment
+}
+
+data "template_file" "app_s3_virus_scan" {
+  template = file("${path.module}/s3_virus_scan.json.tpl")
+
+  vars = {
+    app_image                  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/s3-virus-scan:${var.ecr_image_id_spree}"
+    app_port                   = var.app_port
+    cpu                        = var.cpu
+    memory                     = var.memory
+    aws_region                 = var.aws_region
+    name                       = "s3-virus-scan-task"
+  }
+}
+
+
+resource "aws_ecs_task_definition" "app_s3_virus_scan" {
+  family                   = "s3-virus-scan-task"
+  execution_role_arn       = var.execution_role_arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  container_definitions    = data.template_file.app_s3_virus_scan.rendered
+}
+
+resource "aws_ecs_service" "s3_virus_scan" {
+  name                               = "s3_virus_scan-service"
+  cluster                            = var.ecs_cluster_id
+  task_definition                    = aws_ecs_task_definition.s3_virus_scan.arn
+  desired_count                      = length(var.private_app_subnet_ids)
+  launch_type                        = "EC2"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+
+  network_configuration {
+    security_groups = var.security_groups
+    subnets         = var.private_app_subnet_ids
+  }
+}
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/service/scale/s3_virus_scan"
+  retention_in_days = 7
+}

--- a/terraform/modules/services/s3-virus-scan/s3_virus_scan.json.tpl
+++ b/terraform/modules/services/s3-virus-scan/s3_virus_scan.json.tpl
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "${name}",
+    "image": "${app_image}",
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/service/scale/s3_virus_scan",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "ecs"
+        }
+    },
+    "command": [
+      "bundle", "exec", "ruby","ccs-s3-virus-scan.rb"
+    ],
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "protocol": "tcp"
+      }
+    ]
+  }
+]

--- a/terraform/modules/services/s3-virus-scan/variables.tf
+++ b/terraform/modules/services/s3-virus-scan/variables.tf
@@ -33,3 +33,7 @@ variable "memory" {
 variable "aws_region" {
   type = string
 }
+
+variable "ecr_image_id_s3_virus_scan" {
+  type = string
+}

--- a/terraform/modules/services/s3-virus-scan/variables.tf
+++ b/terraform/modules/services/s3-virus-scan/variables.tf
@@ -50,3 +50,7 @@ variable "security_groups" {
   type = list(string)
 }
 
+variable "lb_private_nlb_arn" {
+  type = string
+}
+

--- a/terraform/modules/services/s3-virus-scan/variables.tf
+++ b/terraform/modules/services/s3-virus-scan/variables.tf
@@ -1,0 +1,35 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "execution_role_arn" {
+  type = string
+}
+
+variable "ecs_cluster_id" {
+  type = string
+}
+
+variable "private_app_subnet_ids" {
+  type = list(string)
+}
+
+variable "app_port" {
+  type = string
+}
+
+variable "cpu" {
+  type = number
+}
+
+variable "memory" {
+  type = number
+}
+
+variable "aws_region" {
+  type = string
+}

--- a/terraform/modules/services/s3-virus-scan/variables.tf
+++ b/terraform/modules/services/s3-virus-scan/variables.tf
@@ -37,3 +37,16 @@ variable "aws_region" {
 variable "ecr_image_id_s3_virus_scan" {
   type = string
 }
+
+variable "deployment_maximum_percent" {
+  type = number
+}
+
+variable "deployment_minimum_healthy_percent" {
+  type = number
+}
+
+variable "security_groups" {
+  type = list(string)
+}
+


### PR DESCRIPTION
My bash at creating the s3-virus-scan service

I haven't include the adding of AWS lambda function.  I will do that as manual task for now,  once we get the service up and run i will create another PR to add the lambda function.

My service is based on this repo https://github.com/ministryofjustice/moj-s3-virus-scan 

![architecture](https://user-images.githubusercontent.com/22822829/104583849-8cd85d00-5659-11eb-94fc-53cd7f40e150.png)


