### PR TITLE
External ALB consolidation - Part 1(a)

### DIFF
--- a/terraform/modules/load-balancer/main.tf
+++ b/terraform/modules/load-balancer/main.tf
@@ -5,115 +5,115 @@
 #
 ##############################################################
 
-# Data sources for the ALB custom domain name and SSL certificate
-data "aws_ssm_parameter" "hosted_zone_name_alb_bat_client" {
-  name = "/bat/${lower(var.environment)}-hosted-zone-name-alb-bat-client"
-}
+# # Data sources for the ALB custom domain name and SSL certificate
+# data "aws_ssm_parameter" "hosted_zone_name_alb_bat_client" {
+#   name = "/bat/${lower(var.environment)}-hosted-zone-name-alb-bat-client"
+# }
 
-data "aws_ssm_parameter" "hosted_zone_name_alb_bat_backend" {
-  name = "/bat/${lower(var.environment)}-hosted-zone-name-alb-bat-backend"
-}
+# data "aws_ssm_parameter" "hosted_zone_name_alb_bat_backend" {
+#   name = "/bat/${lower(var.environment)}-hosted-zone-name-alb-bat-backend"
+# }
 
-module "globals" {
-  source      = "../globals"
-  environment = var.environment
-}
+# module "globals" {
+#   source      = "../globals"
+#   environment = var.environment
+# }
 
-resource "aws_lb" "public_alb" {
-  name               = "SCALE-EU2-${upper(var.environment)}-ALB-EXT-${upper(var.lb_suffix)}"
-  internal           = false
-  load_balancer_type = "application"
-  subnets            = var.public_web_subnet_ids
-  security_groups    = [aws_security_group.public_alb_cf_global.id, aws_security_group.public_alb_cf_regional.id]
-  #depends_on         = [aws_internet_gateway.scale]
+# resource "aws_lb" "public_alb" {
+#   name               = "SCALE-EU2-${upper(var.environment)}-ALB-EXT-${upper(var.lb_suffix)}"
+#   internal           = false
+#   load_balancer_type = "application"
+#   subnets            = var.public_web_subnet_ids
+#   security_groups    = [aws_security_group.public_alb_cf_global.id, aws_security_group.public_alb_cf_regional.id]
+#   #depends_on         = [aws_internet_gateway.scale]
 
-  tags = merge(module.globals.project_resource_tags, { AppType = "LOADBALANCER" })
-}
+#   tags = merge(module.globals.project_resource_tags, { AppType = "LOADBALANCER" })
+# }
 
-resource "aws_security_group" "public_alb_cf_global" {
-  name                   = "allow_alb_external_cloudfront_only_${lower(var.lb_suffix)}"
-  description            = "Allow ingress from Cloudfront only via update sg lambda"
-  vpc_id                 = var.vpc_id
-  revoke_rules_on_delete = true
+# resource "aws_security_group" "public_alb_cf_global" {
+#   name                   = "allow_alb_external_cloudfront_only_${lower(var.lb_suffix)}"
+#   description            = "Allow ingress from Cloudfront only via update sg lambda"
+#   vpc_id                 = var.vpc_id
+#   revoke_rules_on_delete = true
 
-  lifecycle {
-    create_before_destroy = true
-  }
+#   lifecycle {
+#     create_before_destroy = true
+#   }
 
-  # TODO: Use the auto update lambda to manage these ingress rules
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 80
-    to_port     = 80
-  }
+#   # TODO: Use the auto update lambda to manage these ingress rules
+#   ingress {
+#     protocol    = "tcp"
+#     cidr_blocks = ["0.0.0.0/0"]
+#     from_port   = 80
+#     to_port     = 80
+#   }
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 443
-    to_port     = 443
-  }
+#   ingress {
+#     protocol    = "tcp"
+#     cidr_blocks = ["0.0.0.0/0"]
+#     from_port   = 443
+#     to_port     = 443
+#   }
 
-  egress {
-    protocol    = -1
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 0
-    to_port     = 0
-  }
+#   egress {
+#     protocol    = -1
+#     cidr_blocks = ["0.0.0.0/0"]
+#     from_port   = 0
+#     to_port     = 0
+#   }
 
-  tags = merge(module.globals.project_resource_tags, { AppType = "ECS" })
-}
+#   tags = merge(module.globals.project_resource_tags, { AppType = "ECS" })
+# }
 
-resource "aws_security_group" "public_alb_cf_regional" {
-  name                   = "allow_alb_external_cloudfront_only_regional_${lower(var.lb_suffix)}"
-  description            = "Allow ingress from Cloudfront only via update sg lambda"
-  vpc_id                 = var.vpc_id
-  revoke_rules_on_delete = true
+# resource "aws_security_group" "public_alb_cf_regional" {
+#   name                   = "allow_alb_external_cloudfront_only_regional_${lower(var.lb_suffix)}"
+#   description            = "Allow ingress from Cloudfront only via update sg lambda"
+#   vpc_id                 = var.vpc_id
+#   revoke_rules_on_delete = true
 
-  lifecycle {
-    create_before_destroy = true
-  }
+#   lifecycle {
+#     create_before_destroy = true
+#   }
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 80
-    to_port     = 80
-  }
+#   ingress {
+#     protocol    = "tcp"
+#     cidr_blocks = ["0.0.0.0/0"]
+#     from_port   = 80
+#     to_port     = 80
+#   }
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 443
-    to_port     = 443
-  }
-  egress {
-    protocol    = -1
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 0
-    to_port     = 0
-  }
+#   ingress {
+#     protocol    = "tcp"
+#     cidr_blocks = ["0.0.0.0/0"]
+#     from_port   = 443
+#     to_port     = 443
+#   }
+#   egress {
+#     protocol    = -1
+#     cidr_blocks = ["0.0.0.0/0"]
+#     from_port   = 0
+#     to_port     = 0
+#   }
 
-  tags = merge(module.globals.project_resource_tags, { AppType = "ECS" })
-}
+#   tags = merge(module.globals.project_resource_tags, { AppType = "ECS" })
+# }
 
-##############################################################
-# Route53 CDN Alias ('A') record
-##############################################################
-data "aws_route53_zone" "alb" {
-  name         = var.hosted_zone_name
-  private_zone = false
-}
+# ##############################################################
+# # Route53 CDN Alias ('A') record
+# ##############################################################
+# data "aws_route53_zone" "alb" {
+#   name         = var.hosted_zone_name
+#   private_zone = false
+# }
 
-resource "aws_route53_record" "alb" {
-  zone_id = data.aws_route53_zone.alb.zone_id
-  name    = var.hosted_zone_name
-  type    = "A"
+# resource "aws_route53_record" "alb" {
+#   zone_id = data.aws_route53_zone.alb.zone_id
+#   name    = var.hosted_zone_name
+#   type    = "A"
 
-  alias {
-    name                   = aws_lb.public_alb.dns_name
-    zone_id                = aws_lb.public_alb.zone_id
-    evaluate_target_health = true
-  }
-}
+#   alias {
+#     name                   = aws_lb.public_alb.dns_name
+#     zone_id                = aws_lb.public_alb.zone_id
+#     evaluate_target_health = true
+#   }
+# }

--- a/terraform/modules/load-balancer/outputs.tf
+++ b/terraform/modules/load-balancer/outputs.tf
@@ -1,7 +1,7 @@
-output "lb_public_alb_arn" {
-  value = aws_lb.public_alb.arn
-}
+# output "lb_public_alb_arn" {
+#   value = aws_lb.public_alb.arn
+# }
 
-output "lb_public_alb_dns" {
-  value = aws_lb.public_alb.dns_name
-}
+# output "lb_public_alb_dns" {
+#   value = aws_lb.public_alb.dns_name
+# }

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -46,7 +46,7 @@ data "aws_acm_certificate" "alb" {
 
 resource "aws_lb_listener" "port_443" {
   load_balancer_arn = var.lb_public_alb_arn
-  port              = "443"
+  port              = "4453"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
   certificate_arn   = data.aws_acm_certificate.alb.arn
@@ -57,6 +57,35 @@ resource "aws_lb_listener" "port_443" {
   }
 }
 
+# data "aws_ssm_parameter" "external_alb_port_443_listener_arn" {
+#   name = "${lower(var.environment)}-ext-alb-port-443-listener-arn"
+# }
+
+# resource "aws_lb_listener_certificate" "bat_client" {
+#   listener_arn    = data.aws_ssm_parameter.external_alb_port_443_listener_arn.value
+#   certificate_arn = data.aws_acm_certificate.alb.arn
+# }
+
+# resource "aws_lb_listener_rule" "authenticate_cloudfront" {
+#   listener_arn = data.aws_ssm_parameter.external_alb_port_443_listener_arn.value
+#   # priority     = 1
+
+#   action {
+#     type             = "forward"
+#     target_group_arn = aws_lb_target_group.target_group_8080.arn
+#   }
+
+#   condition {
+#     # http_header {
+#     #   http_header_name = "CloudFrontID"
+#     #   values           = [var.cloudfront_id]
+#     # }
+
+#     host_header {
+#       values = [var.hosted_zone_name]
+#     }
+#   }
+# }
 
 # https://github.com/hashicorp/terraform/issues/19601
 data "template_file" "app_client" {

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -41,7 +41,7 @@ data "aws_acm_certificate" "alb" {
 
 resource "aws_lb_listener" "port_443" {
   load_balancer_arn = var.lb_public_alb_arn
-  port              = "443"
+  port              = "4443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
   certificate_arn   = data.aws_acm_certificate.alb.arn
@@ -51,6 +51,36 @@ resource "aws_lb_listener" "port_443" {
     target_group_arn = aws_lb_target_group.target_group_4567.arn
   }
 }
+
+# data "aws_ssm_parameter" "external_alb_port_443_listener_arn" {
+#   name = "${lower(var.environment)}-ext-alb-port-443-listener-arn"
+# }
+
+# resource "aws_lb_listener_certificate" "bat_client" {
+#   listener_arn    = data.aws_ssm_parameter.external_alb_port_443_listener_arn.value
+#   certificate_arn = data.aws_acm_certificate.alb.arn
+# }
+
+# resource "aws_lb_listener_rule" "authenticate_cloudfront" {
+#   listener_arn = data.aws_ssm_parameter.external_alb_port_443_listener_arn.value
+#   # priority     = 1
+
+#   action {
+#     type             = "forward"
+#     target_group_arn = aws_lb_target_group.target_group_4567.arn
+#   }
+
+#   condition {
+#     # http_header {
+#     #   http_header_name = "CloudFrontID"
+#     #   values           = [var.cloudfront_id]
+#     # }
+
+#     host_header {
+#       values = [var.hosted_zone_name]
+#     }
+#   }
+# }
 
 #######################################################################
 # NLB target group & listener for traffic on port 80 -> 4567 (Spree app)

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -18,10 +18,6 @@ variable "lb_public_alb_arn" {
   type = string
 }
 
-variable "lb_public_alb_dns" {
-  type = string
-}
-
 variable "lb_private_nlb_arn" {
   type = string
 }


### PR DESCRIPTION
**TARGETS SINF-314 - REBASE AFTER APPLICATION / MERGE**
As mentioned I think we will have to merge / run these changes in stages as follows to avoid dependency / LB errors and also to avoid tearing down and rebuilding.  Will necessitate a short period of downtime.

1. Changes on this PR (and to a lesser extent [sibling PR for FaT](https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-fat/pull/159)):
    - Remove the BaT ALBs
    - Swap the existing listeners over to a temporary port and to the shared external ALB
 2. Part 2 in [this PR](https://github.com/Crown-Commercial-Service/ccs-scale-infrastructure/pull/56) in ccs-scale-infrastructure creates a new shared listener on port 443 plus R53 config for BaT.
 3. Part 3 across final [BaT PR](https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-bat/pull/38) and [FaT PR](https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-fat/pull/160) services re-attach the necessary listener rules and tidy up

The above went through more or less exactly as-is in SBX2, but needless to say there was a bit of hacking about so need to verify on at least one other environment (SBX1 then NFT?).  Open to debate how we manage the branches / merging / rollout..

Finally - apologies - this PR leaves a bit of commented out mess - rest assured it's all tidied in [Part 3(a)](https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-bat/pull/38).
