### PR TITLE
Add ENV variables to allow  s3-virus-scan service access s3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Check the README file for details of how to create the database.
   /bat/{env}-lograge-enabled
   /bat/{env}-sendgrid-api-key
   /bat/{env}-mail-from
+  /bat/{env}-aws_access_key_id
+  /bat/{env}-aws_secret_access_key
 ```
 
 4. Run `terraform apply`

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -47,7 +47,7 @@ module "deploy" {
 
   # default values for s3-virus-scan-service subject to change based on testing on DEV
   ecr_image_id_s3_virus_scan      = "latest"
-  s3_virus_scan_cpu               = 1024
-  s3_virus_scan_memory            = 2048
-  s3_virus_scan_ec2_instance_type = "t2.medium"
+  s3_virus_scan_cpu               = 2048
+  s3_virus_scan_memory            = 4096
+  s3_virus_scan_ec2_instance_type = "t2.large"
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -134,6 +134,14 @@ data "aws_ssm_parameter" "mail_from" {
   name = "/bat/${lower(var.environment)}-mail-from"
 }
 
+data "aws_ssm_parameter" "aws_access_key_id" {
+  name = "/bat/${lower(var.environment)}-aws-access-key-id"
+}
+
+data "aws_ssm_parameter" "aws_secret_access_key" {
+  name = "/bat/${lower(var.environment)}-aws-secret-access-key"
+}
+
 ######################################
 # CIDR ranges for whitelisting
 ######################################
@@ -607,4 +615,6 @@ module "s3_virus_scan" {
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   security_groups                    = [aws_security_group.s3-virus-scan.id]
+  aws_access_key_id                  = data.aws_ssm_parameter.aws_access_key_id.value
+  aws_secret_access_key              = data.aws_ssm_parameter.aws_secret_access_key.value
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -387,6 +387,11 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_s3" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_read_ssm" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}
+
 ######################################
 # Modules
 ######################################
@@ -615,6 +620,6 @@ module "s3_virus_scan" {
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   security_groups                    = [aws_security_group.s3-virus-scan.id]
-  aws_access_key_id                  = data.aws_ssm_parameter.aws_access_key_id.value
-  aws_secret_access_key              = data.aws_ssm_parameter.aws_secret_access_key.value
+  aws_access_key_id                  = data.aws_ssm_parameter.aws_access_key_id.arn
+  aws_secret_access_key              = data.aws_ssm_parameter.aws_secret_access_key.arn
 }

--- a/terraform/modules/services/s3-virus-scan/ecs.tf
+++ b/terraform/modules/services/s3-virus-scan/ecs.tf
@@ -32,12 +32,14 @@ data "template_file" "app_s3_virus_scan" {
   template = file("${path.module}/s3_virus_scan.json.tpl")
 
   vars = {
-    app_image  = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/s3-virus-scan:${var.ecr_image_id_s3_virus_scan}"
-    app_port   = var.app_port
-    cpu        = var.cpu
-    memory     = var.memory
-    aws_region = var.aws_region
-    name       = "s3-virus-scan-task"
+    app_image              = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/s3-virus-scan:${var.ecr_image_id_s3_virus_scan}"
+    app_port               = var.app_port
+    cpu                    = var.cpu
+    memory                 = var.memory
+    aws_region             = var.aws_region
+    name                   = "s3-virus-scan-task"
+    aws_access_key_id      = var.aws_access_key_id
+    aws_secret_access_key  = var.aws_secret_access_key
   }
 }
 

--- a/terraform/modules/services/s3-virus-scan/s3_virus_scan.json.tpl
+++ b/terraform/modules/services/s3-virus-scan/s3_virus_scan.json.tpl
@@ -13,6 +13,20 @@
           "awslogs-stream-prefix": "ecs"
         }
     },
+    "environment": [
+      {
+        "name": "AWS_REGION",
+        "value": "${aws_region}"
+      },
+      {
+        "name": "AWS_ACCESS_KEY_ID",
+        "value": "${aws_access_key_id}"
+      },
+      {
+        "name": "AWS_SECRET_ACCESS_KEY",
+        "value": "${aws_secret_access_key}"
+      }
+    ],
     "command": [
       "bundle", "exec", "ruby","ccs-s3-virus-scan.rb"
     ],

--- a/terraform/modules/services/s3-virus-scan/s3_virus_scan.json.tpl
+++ b/terraform/modules/services/s3-virus-scan/s3_virus_scan.json.tpl
@@ -17,7 +17,9 @@
       {
         "name": "AWS_REGION",
         "value": "${aws_region}"
-      },
+      }
+    ],
+    "secrets": [
       {
         "name": "AWS_ACCESS_KEY_ID",
         "value": "${aws_access_key_id}"

--- a/terraform/modules/services/s3-virus-scan/variables.tf
+++ b/terraform/modules/services/s3-virus-scan/variables.tf
@@ -54,3 +54,12 @@ variable "lb_private_nlb_arn" {
   type = string
 }
 
+variable "aws_access_key_id" {
+  type = string
+}
+
+variable "aws_secret_access_key" {
+  type = string
+}
+
+


### PR DESCRIPTION
I need to add the following environment variables: 
- aws_access_key_id 
- aws_secret_access_key

I have notice that these environment variables haven't been added for spree/client and they are still being added from the env file in S3.

Any reason why i can't remove them from the file and update this PR to include the client and Spree?