### PR TITLE
Change Buyer UI networking mode

### DIFF
--- a/terraform/modules/_to_delete/api.tf
+++ b/terraform/modules/_to_delete/api.tf
@@ -26,10 +26,10 @@ module "client_cors" {
 }
 
 resource "aws_api_gateway_method" "client_proxy" {
-  rest_api_id      = var.scale_rest_api_id
-  resource_id      = aws_api_gateway_resource.client_proxy.id
-  http_method      = "ANY"
-  authorization    = "NONE"
+  rest_api_id   = var.scale_rest_api_id
+  resource_id   = aws_api_gateway_resource.client_proxy.id
+  http_method   = "ANY"
+  authorization = "NONE"
   //api_key_required = true
 
   request_parameters = {

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,7 +1,7 @@
 output "redis_url" {
-    value = "redis://${aws_elasticache_replication_group.redis.primary_endpoint_address}"
+  value = "redis://${aws_elasticache_replication_group.redis.primary_endpoint_address}"
 }
 
 output "memcached_endpoint" {
-    value = aws_elasticache_cluster.memcached.cluster_address
+  value = aws_elasticache_cluster.memcached.cluster_address
 }

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -16,7 +16,7 @@ resource "aws_lb_target_group" "target_group_8080" {
   name        = "SCALE-EU2-${upper(var.environment)}-VPC-BaTClient"
   port        = 8080
   protocol    = "HTTP"
-  target_type = "ip"
+  target_type = "instance"
   vpc_id      = var.vpc_id
 
   stickiness {
@@ -89,7 +89,7 @@ data "template_file" "app_client" {
 resource "aws_ecs_task_definition" "app_client" {
   family                   = "client-app-task"
   execution_role_arn       = var.execution_role_arn
-  network_mode             = "awsvpc"
+  network_mode             = "host"
   requires_compatibilities = ["EC2"]
   cpu                      = var.cpu
   memory                   = var.memory
@@ -105,11 +105,6 @@ resource "aws_ecs_service" "client" {
   launch_type                        = "EC2"
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  network_configuration {
-    security_groups = var.security_groups
-    subnets         = var.public_web_subnet_ids
-  }
 
   load_balancer {
     target_group_arn = aws_lb_target_group.target_group_8080.arn

--- a/terraform/modules/services/s3-virus-scan/ecs.tf
+++ b/terraform/modules/services/s3-virus-scan/ecs.tf
@@ -32,14 +32,14 @@ data "template_file" "app_s3_virus_scan" {
   template = file("${path.module}/s3_virus_scan.json.tpl")
 
   vars = {
-    app_image              = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/s3-virus-scan:${var.ecr_image_id_s3_virus_scan}"
-    app_port               = var.app_port
-    cpu                    = var.cpu
-    memory                 = var.memory
-    aws_region             = var.aws_region
-    name                   = "s3-virus-scan-task"
-    aws_access_key_id      = var.aws_access_key_id
-    aws_secret_access_key  = var.aws_secret_access_key
+    app_image             = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/s3-virus-scan:${var.ecr_image_id_s3_virus_scan}"
+    app_port              = var.app_port
+    cpu                   = var.cpu
+    memory                = var.memory
+    aws_region            = var.aws_region
+    name                  = "s3-virus-scan-task"
+    aws_access_key_id     = var.aws_access_key_id
+    aws_secret_access_key = var.aws_secret_access_key
   }
 }
 
@@ -96,10 +96,10 @@ resource "aws_security_group_rule" "s3-virus-scan-lambda-allow-http" {
 }
 
 module "s3_virus_scan_lambda" {
-  source           = "./lambda"
-  environment      = var.environment
-  host             = var.host
-  subnet_ids       = var.private_app_subnet_ids
-  security_groups  =[aws_security_group.s3-virus-scan-lambda.id]
+  source          = "./lambda"
+  environment     = var.environment
+  host            = var.host
+  subnet_ids      = var.private_app_subnet_ids
+  security_groups = [aws_security_group.s3-virus-scan-lambda.id]
 }
 

--- a/terraform/modules/services/s3-virus-scan/lambda/main.tf
+++ b/terraform/modules/services/s3-virus-scan/lambda/main.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "lambda_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      type     = "Service"
+      type        = "Service"
       identifiers = ["lambda.amazonaws.com", "s3.amazonaws.com"]
     }
   }
@@ -32,7 +32,7 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
 }
 
 data "archive_file" "lambda_ccs_virus_scan_zip" {
-  type          = "zip"
+  type        = "zip"
   source_dir  = "${path.module}/ccs-virus-scan"
   output_path = "${path.module}/.build/ccs-virus-scan.zip"
 }


### PR DESCRIPTION
Looks like the formatter caught some extras here, apologies.  Changes are all under https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-bat/compare/feature/SINF-352_buyer_ui_networking_mode?expand=1#diff-2dde62e2bbaf8f99f4462407897c7675a4d830eafbdbe39532aa517880ab1151 

Applied to SBX2.  Had to remove current listener rule for the target group and then also manually delete the target group for changes to go through.  
Was then able to curl / telnet from both the EC2 instance and the Buyer UI container to external resources including Logit.io ES host/port:
```
root@ip-192-168-1-115:/app# curl https://6746d308-cf02-4757-bc04-e62f3fcbe137-es.logit.io:9200
{"message":"No API key found in request"}
```
**NB** The NodeJS slim image does not ship with anything useful like `curl` or `telnet`.  To test the changes you'll have to enter the container shell as root and then install something, e.g.

```
$ docker exec -u root -it [container_id] bash
$ apt-get update && apt-get install -y curl
```
etc - although `apt-get update` won't work until the changes are applied so that's as good a test as any I guess!