### PR TITLE
Feature/sinf 356 param tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,76 +13,40 @@ Check the README file for details of how to create the database.
 
 ### Pre install steps
 
-1. Create IAM user called `spree-user` with policy (`app-policy`) allowing full access to S3 (TODO: this needs to be reviewed/tied down)
-  - Add AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY values to `spree.env`
+1. Create IAM user called `spree-user` with policy (`app-policy`) allowing full access to S3 (TODO: scripting of this added under SINF-372)
 
 2. Create an key pair instance called `{env}-spree-key'`
 
 3. Create SSM Params
-```
-  /bat/{env}-rollbar-access-token - token to send errors to rollbar
-	/bat/{env}-secret-key-base - secret key for the spree app
-  /bat/{env}-basic-auth-username - basic auth username for spree app and the client
-  /bat/{env}-basic-auth-password - basic auth password for spree app and the client
-  /bar/{env}-basic-auth-enabled - flag to enable/disable basic auth
-  /bat/{env}-session-cookie-secret - client session cookie secret
-  /bat/{env}-products-import-bucket - s3 bucket in which supplier import are progress
-  /bat/{env}-logit-hostname - logit.io endpoint
-  /bat/{env}-logit-remote-port - port to send logs to logit.io
-  /bat/{env}-suppliers-sftp-bucket - S3 bucket which holds suppliers sftp buckets
-  /bat/{env}-documents-terms-and-conditions-url - ulr
-  /bat/{env}-lograge-enabled - flag to enable log forrmating in spree
-  /bat/{env}-sendgrid-api-key - api key to sendgrid
-  /bat/{env}-mail-from - email address which email are sent from spree
-  /bat/{env}-aws_access_key_id - spree user access key id
-  /bat/{env}-aws_secret_access_key - spree user secret access key
-  /bat/{env}-sidekiq-concurrency - number of concurrent sidekiq workers
-  /bat/{env}-sidekiq-concurrency-searchkick - number of concurrent sidekiq workers for searchkick jobs
-  /bat/{env}-logit-node - url to logit.io elasticsearch cluster
-  /bat/{env}-browser-rollbar-access-token - client side rollbar token
-  /bat/{env}-cnet-ftp-username - username to cnet ftp site
-  /bat/{env}-cnet-ftp-endpoint - address to cnet ftp site
-  /bat/{env}-cnet-ftp-password - password to cnet ftp site
-  /bat/{env}-cnet-ftp-port - port to access cnet ftp site
-  /bat/{env}-elasticsearch-limit - limit the results return for elastic search query
-  /bat/{env}-enable-quotes - flag to enable/disable quotes in the buyer ui
-  /bat/{env}-enable-basket - flag to enable/disable the basket in the buyer ui
-  /bat/{env}-logit-application - send the name of app to logit.io
-```
+
+| System Parameter                        | Description |
+| ----------------------------------------|-------------|
+| /bat/{env}-rollbar-access-token         | token to send errors to rollbar |
+| /bat/{env}-secret-key-base              | secret key for the spree app |
+| /bat/{env}-basic-auth-username          | basic auth username for spree app and the client |
+| /bat/{env}-basic-auth-password          | basic auth password for spree app and the client |
+| /bar/{env}-basic-auth-enabled           | flag to enable/disable basic auth |
+| /bat/{env}-session-cookie-secret        | client session cookie secret |
+| /bat/{env}-products-import-bucket       | s3 bucket in which supplier import are progress |
+| /bat/{env}-logit-hostname               | logit.io endpoint |
+| /bat/{env}-logit-remote-port            | port to send logs to logit.io |
+| /bat/{env}-suppliers-sftp-bucket        | S3 bucket which holds suppliers sftp buckets |
+| /bat/{env}-sendgrid-api-key             | api key to sendgrid |
+| /bat/{env}-aws-access-key-id            | spree-user access key id |
+| /bat/{env}-aws-secret-access-key        | spree-user secret access key |
+| /bat/{env}-logit-node                   | url to logit.io elasticsearch cluster |
+| /bat/{env}-browser-rollbar-access-token | client side rollbar token |
+| /bat/{env}-cnet-ftp-username            | username to cnet ftp site |
+| /bat/{env}-cnet-ftp-password            | password to cnet ftp site |
+| /bat/{env}-sidekiq-username             | can be any value - internal BaT use only |
+| /bat/{env}-sidekiq-password             | can be any value - internal BaT use only |
+| /bat/{env}-sendgrid-username            | username for sendgrid site |
+| /bat/{env}-sendgrid-password            | password for sendgrid site |
+| /bat/{env}-new-relic-license-key        | key from new relic site |
+
 
 4. Run `terraform apply`
- - It will provision everything, but not ECS - as key is missing - but will have enough to complete step 5 now
- - (this is just hack to work around this cyclic dependency - need a better solution)
-
-5. Create `client.env` environment file
-
-```
-SESSION_COOKIE_SECRET={RANDOM_STRING? NOT SURE}
-DOCUMENTS_TERMS_AND_CONDITIONS_URL=https://purchasingplatform.crowncommercial.gov.uk/
-```
-
-6. Create `spree.env` environment file
-
-```
-SIDEKIQ_USERNAME={}
-SIDEKIQ_PASSWORD={}
-SENDGRID_USERNAME={}
-SENDGRID_PASSWORD={}
-AWS_REGION=eu-west-2
-AWS_ACCESS_KEY_ID={VALUE_FROM_IAM_USER_ABOVE}
-AWS_SECRET_ACCESS_KEY={VALUE_FROM_IAM_USER_ABOVE}
-S3_REGION=eu-west-2
-S3_BUCKET_NAME=spree-${lower(var.environment)}-${lower(var.stage)}
-```
-
-7. Upload `client.env` and `spree.env` to the provisioned S3 bucket `system-spree-[env]-staging`
-
-8. Update the services
- - simple hack for this is to change the docker image to some random id - run `terraform apply`
- - then switch it to 'latest' again and rerun `terraform apply`
- - this whole part of the process needs review
-
-NOTE/TODO: For steps 3 & 4 you have to provision the everything first to get the values to put into these files, so you then have to redploy the ECS Services - can we move these to environment variables rather than files (need to check with Sparks about this). There is also some duplication between env variables and file - is this necessary?
+ - This will provision the BaT service components
 
 ### Post install steps
 When first building on a clean environment - the database will not be populated. To populate the database you need to connect to the docker container running in the relevant ECS/EC2 instance and execute a command

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -27,23 +27,24 @@ data "aws_ssm_parameter" "aws_account_id" {
 }
 
 module "deploy" {
-  source                    = "../../modules/configs/deploy-all"
-  aws_account_id            = data.aws_ssm_parameter.aws_account_id.value
-  environment               = local.environment
-  rollbar_env               = local.environment
-  ecr_image_id_spree        = "latest"
-  ecr_image_id_client       = "latest"
-  client_cpu                = 2048
-  client_memory             = 4096 #t2.large - 8GB available
-  client_ec2_instance_type  = "t2.large"
-  spree_cpu                 = 4096
-  spree_memory              = 8192 #t2.xlarge - 16GB available
-  spree_ec2_instance_type   = "t2.xlarge"
-  sidekiq_cpu               = 4096
-  sidekiq_memory            = 8192 #t2.xlarge - 16GB available
-  sidekiq_ec2_instance_type = "t2.xlarge"
-  memcached_node_type       = "cache.t3.medium"
-  redis_node_type           = "cache.t3.medium"
+  source                               = "../../modules/configs/deploy-all"
+  aws_account_id                       = data.aws_ssm_parameter.aws_account_id.value
+  environment                          = local.environment
+  rollbar_env                          = local.environment
+  ecr_image_id_spree                   = "latest"
+  ecr_image_id_client                  = "latest"
+  client_cpu                           = 2048
+  client_memory                        = 4096 #t2.large - 8GB available
+  client_ec2_instance_type             = "t2.large"
+  spree_cpu                            = 4096
+  spree_memory                         = 8192 #t2.xlarge - 16GB available
+  spree_ec2_instance_type              = "t2.xlarge"
+  sidekiq_cpu                          = 4096
+  sidekiq_memory                       = 8192 #t2.xlarge - 16GB available
+  sidekiq_ec2_instance_type            = "t2.xlarge"
+  memcached_node_type                  = "cache.t3.medium"
+  redis_node_type                      = "cache.t3.medium"
+  error_pages_unknonwn_server_endpoint = true
 
   # default values for s3-virus-scan-service subject to change based on testing on DEV
   ecr_image_id_s3_virus_scan      = "latest"

--- a/terraform/environments/int/main.tf
+++ b/terraform/environments/int/main.tf
@@ -48,5 +48,5 @@ module "deploy" {
   s3_virus_scan_cpu               = 2048
   s3_virus_scan_memory            = 4096
   s3_virus_scan_ec2_instance_type = "t2.large"
-
+  basic_auth_enabled              = false
 }

--- a/terraform/environments/sbx8/main.tf
+++ b/terraform/environments/sbx8/main.tf
@@ -49,4 +49,7 @@ module "deploy" {
   s3_virus_scan_cpu               = 2048
   s3_virus_scan_memory            = 4096
   s3_virus_scan_ec2_instance_type = "t2.large"
+  enable_quotes                   = false
+  enable_basket                   = false
+  logit_application               = "BAT-Buyer-UI-REF"
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -13,8 +13,9 @@ provider "aws" {
 }
 
 locals {
-  aws_region    = "eu-west-2"
-  spree_db_name = "spree"
+  aws_region            = "eu-west-2"
+  spree_db_name         = "spree"
+  suppliers_sftp_bucket = "scale-${var.environment}-s3-aws-sftp"
 }
 
 data "aws_ssm_parameter" "vpc_id" {
@@ -57,6 +58,10 @@ data "aws_ssm_parameter" "spree_db_endpoint" {
   name = "/bat/${lower(var.environment)}-spree-db-endpoint"
 }
 
+data "aws_ssm_parameter" "elasticsearch_url" {
+  name = "/bat/${lower(var.environment)}-elasticsearch-url"
+}
+
 #######################################################
 # Following need to be added manually as SSM Parameters
 #######################################################
@@ -76,16 +81,8 @@ data "aws_ssm_parameter" "basic_auth_password" {
   name = "/bat/${lower(var.environment)}-basic-auth-password"
 }
 
-data "aws_ssm_parameter" "basic_auth_enabled" {
-  name = "/bat/${lower(var.environment)}-basic-auth-enabled"
-}
-
 data "aws_ssm_parameter" "client_session_secret" {
   name = "/bat/${lower(var.environment)}-session-cookie-secret"
-}
-
-data "aws_ssm_parameter" "products_import_bucket" {
-  name = "/bat/${lower(var.environment)}-products-import-bucket"
 }
 
 data "aws_ssm_parameter" "spree_db_username" {
@@ -96,18 +93,6 @@ data "aws_ssm_parameter" "spree_db_username" {
 data "aws_ssm_parameter" "spree_db_password" {
   name            = "/bat/${lower(var.environment)}-spree-db-app-password"
   with_decryption = true
-}
-
-data "aws_ssm_parameter" "elasticsearch_url" {
-  name = "/bat/${lower(var.environment)}-elasticsearch-url"
-}
-
-data "aws_ssm_parameter" "logit_hostname" {
-  name = "/bat/${lower(var.environment)}-logit-hostname"
-}
-
-data "aws_ssm_parameter" "logit_remote_port" {
-  name = "/bat/${lower(var.environment)}-logit-remote-port"
 }
 
 data "aws_ssm_parameter" "hosted_zone_name_alb_bat_client" {
@@ -126,24 +111,8 @@ data "aws_ssm_parameter" "hosted_zone_name_cdn_bat_backend" {
   name = "/bat/${lower(var.environment)}-hosted-zone-name-cdn-bat-backend"
 }
 
-data "aws_ssm_parameter" "suppliers_sftp_bucket" {
-  name = "/bat/${lower(var.environment)}-suppliers-sftp-bucket"
-}
-
-data "aws_ssm_parameter" "documents_terms_and_conditions_url" {
-  name = "/bat/${lower(var.environment)}-documents-terms-and-conditions-url"
-}
-
-data "aws_ssm_parameter" "lograge_enabled" {
-  name = "/bat/${lower(var.environment)}-lograge-enabled"
-}
-
 data "aws_ssm_parameter" "sendgrid_api_key" {
   name = "/bat/${lower(var.environment)}-sendgrid-api-key"
-}
-
-data "aws_ssm_parameter" "mail_from" {
-  name = "/bat/${lower(var.environment)}-mail-from"
 }
 
 data "aws_ssm_parameter" "aws_access_key_id" {
@@ -151,18 +120,6 @@ data "aws_ssm_parameter" "aws_access_key_id" {
 }
 data "aws_ssm_parameter" "aws_secret_access_key" {
   name = "/bat/${lower(var.environment)}-aws-secret-access-key"
-}
-
-data "aws_ssm_parameter" "sidekiq_concurrency" {
-  name = "/bat/${lower(var.environment)}-sidekiq-concurrency"
-}
-
-data "aws_ssm_parameter" "sidekiq_concurrency_searchkick" {
-  name = "/bat/${lower(var.environment)}-sidekiq-concurrency-searchkick"
-}
-
-data "aws_ssm_parameter" "logit_node" {
-  name = "/bat/${lower(var.environment)}-logit-node"
 }
 
 data "aws_ssm_parameter" "browser_rollbar_access_token" {
@@ -173,26 +130,6 @@ data "aws_ssm_parameter" "lb_public_alb_arn" {
   name = "${lower(var.environment)}-lb-public-alb-arn"
 }
 
-data "aws_ssm_parameter" "enable_basket" {
-  name = "/bat/${lower(var.environment)}-enable-basket"
-}
-
-data "aws_ssm_parameter" "enable_quotes" {
-  name = "/bat/${lower(var.environment)}-enable-quotes"
-}
-
-data "aws_ssm_parameter" "elasticsearch_limit" {
-  name = "/bat/${lower(var.environment)}-elasticsearch-limit"
-}
-
-data "aws_ssm_parameter" "cnet_ftp_endpoint" {
-  name = "/bat/${lower(var.environment)}-cnet-ftp-endpoint"
-}
-
-data "aws_ssm_parameter" "cnet_ftp_port" {
-  name = "/bat/${lower(var.environment)}-cnet-ftp-port"
-}
-
 data "aws_ssm_parameter" "cnet_ftp_username" {
   name = "/bat/${lower(var.environment)}-cnet-ftp-username"
 }
@@ -201,8 +138,36 @@ data "aws_ssm_parameter" "cnet_ftp_password" {
   name = "/bat/${lower(var.environment)}-cnet-ftp-password"
 }
 
-data "aws_ssm_parameter" "logit_application" {
-  name = "/bat/${lower(var.environment)}-logit-application"
+data "aws_ssm_parameter" "logit_hostname" {
+  name = "/bat/${lower(var.environment)}-logit-hostname"
+}
+
+data "aws_ssm_parameter" "logit_remote_port" {
+  name = "/bat/${lower(var.environment)}-logit-remote-port"
+}
+
+data "aws_ssm_parameter" "logit_node" {
+  name = "/bat/${lower(var.environment)}-logit-node"
+}
+
+data "aws_ssm_parameter" "sidekiq_username" {
+  name = "/bat/${lower(var.environment)}-sidekiq-username"
+}
+
+data "aws_ssm_parameter" "sidekiq_password" {
+  name = "/bat/${lower(var.environment)}-sidekiq-password"
+}
+
+data "aws_ssm_parameter" "sendgrid_username" {
+  name = "/bat/${lower(var.environment)}-sendgrid-username"
+}
+
+data "aws_ssm_parameter" "sendgrid_password" {
+  name = "/bat/${lower(var.environment)}-sendgrid-password"
+}
+
+data "aws_ssm_parameter" "new_relic_license_key" {
+  name = "/bat/${lower(var.environment)}-new-relic-license-key"
 }
 
 ######################################
@@ -526,14 +491,8 @@ module "spree" {
   aws_region                         = local.aws_region
   db_name                            = local.spree_db_name
   db_host                            = data.aws_ssm_parameter.spree_db_endpoint.value
-  db_username                        = data.aws_ssm_parameter.spree_db_username.value
-  db_password                        = data.aws_ssm_parameter.spree_db_password.value
-  secret_key_base                    = data.aws_ssm_parameter.secret_key_base.value
-  rollbar_access_token               = data.aws_ssm_parameter.rollbar_access_token.value
-  basicauth_username                 = data.aws_ssm_parameter.basic_auth_username.value
-  basicauth_password                 = data.aws_ssm_parameter.basic_auth_password.value
-  basicauth_enabled                  = data.aws_ssm_parameter.basic_auth_enabled.value
-  products_import_bucket             = data.aws_ssm_parameter.products_import_bucket.value
+  basicauth_enabled                  = var.basic_auth_enabled
+  products_import_bucket             = module.s3.s3_product_import_name
   rollbar_env                        = var.rollbar_env
   redis_url                          = module.memcached.redis_url
   memcached_endpoint                 = module.memcached.memcached_endpoint
@@ -544,22 +503,39 @@ module "spree" {
   elasticsearch_url                  = "https://${data.aws_ssm_parameter.elasticsearch_url.value}:443"
   buyer_ui_url                       = "https://${data.aws_ssm_parameter.hosted_zone_name_cdn_bat_client.value}"
   app_domain                         = data.aws_ssm_parameter.hosted_zone_name_cdn_bat_backend.value
-  logit_hostname                     = data.aws_ssm_parameter.logit_hostname.value
-  logit_remote_port                  = data.aws_ssm_parameter.logit_remote_port.value
-  suppliers_sftp_bucket              = data.aws_ssm_parameter.suppliers_sftp_bucket.value
+  suppliers_sftp_bucket              = local.suppliers_sftp_bucket
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  lograge_enabled                    = data.aws_ssm_parameter.lograge_enabled.value
-  sendgrid_api_key                   = data.aws_ssm_parameter.sendgrid_api_key.value
-  mail_from                          = data.aws_ssm_parameter.mail_from.value
-  sidekiq_concurrency                = data.aws_ssm_parameter.sidekiq_concurrency.value
-  sidekiq_concurrency_searchkick     = data.aws_ssm_parameter.sidekiq_concurrency_searchkick.value
-  elasticsearch_limit                = data.aws_ssm_parameter.elasticsearch_limit.value
-  cnet_ftp_endpoint                  = data.aws_ssm_parameter.cnet_ftp_endpoint.value
-  cnet_ftp_port                      = data.aws_ssm_parameter.cnet_ftp_port.value
-  cnet_ftp_username                  = data.aws_ssm_parameter.cnet_ftp_username.value
-  cnet_ftp_password                  = data.aws_ssm_parameter.cnet_ftp_password.value
+  lograge_enabled                    = var.lograge_enabled
+  mail_from                          = var.email_from
+  sidekiq_concurrency                = var.sidekiq_concurrency
+  sidekiq_concurrency_searchkick     = var.sidekiq_concurrency_searchkick
+  elasticsearch_limit                = var.elasticsearch_limit
+  cnet_ftp_endpoint                  = var.cnet_ftp_endpoint
+  cnet_ftp_port                      = var.cnet_ftp_port
+  s3_static_bucket_name              = module.s3.s3_static_bucket_name
+  new_relic_app_name                 = var.new_relic_app_name == null ? "BAT Spree ${upper(var.environment)}" : var.new_relic_app_name
+  new_relic_agent_enabled            = var.new_relic_agent_enabled
   default_country_id                 = var.default_country_id
+  # Secrets
+  aws_access_key_id_ssm_arn     = data.aws_ssm_parameter.aws_access_key_id.arn
+  aws_secret_access_key_ssm_arn = data.aws_ssm_parameter.aws_secret_access_key.arn
+  basicauth_username_ssm_arn    = data.aws_ssm_parameter.basic_auth_username.arn
+  basicauth_password_ssm_arn    = data.aws_ssm_parameter.basic_auth_password.arn
+  cnet_ftp_username_ssm_arn     = data.aws_ssm_parameter.cnet_ftp_username.arn
+  cnet_ftp_password_ssm_arn     = data.aws_ssm_parameter.cnet_ftp_password.arn
+  db_username_ssm_arn           = data.aws_ssm_parameter.spree_db_username.arn
+  db_password_ssm_arn           = data.aws_ssm_parameter.spree_db_password.arn
+  logit_hostname_ssm_arn        = data.aws_ssm_parameter.logit_hostname.arn
+  logit_remote_port_ssm_arn     = data.aws_ssm_parameter.logit_remote_port.arn
+  new_relic_license_key_ssm_arn = data.aws_ssm_parameter.new_relic_license_key.arn
+  rollbar_access_token_ssm_arn  = data.aws_ssm_parameter.rollbar_access_token.arn
+  secret_key_base_ssm_arn       = data.aws_ssm_parameter.secret_key_base.arn
+  sendgrid_username_ssm_arn     = data.aws_ssm_parameter.sendgrid_username.arn
+  sendgrid_password_ssm_arn     = data.aws_ssm_parameter.sendgrid_password.arn
+  sendgrid_api_key_ssm_arn      = data.aws_ssm_parameter.sendgrid_api_key.arn
+  sidekiq_username_ssm_arn      = data.aws_ssm_parameter.sidekiq_username.arn
+  sidekiq_password_ssm_arn      = data.aws_ssm_parameter.sidekiq_password.arn
 }
 
 ######################################
@@ -579,14 +555,8 @@ module "sidekiq" {
   aws_region                         = local.aws_region
   db_name                            = local.spree_db_name
   db_host                            = data.aws_ssm_parameter.spree_db_endpoint.value
-  db_username                        = data.aws_ssm_parameter.spree_db_username.value
-  db_password                        = data.aws_ssm_parameter.spree_db_password.value
-  secret_key_base                    = data.aws_ssm_parameter.secret_key_base.value
-  rollbar_access_token               = data.aws_ssm_parameter.rollbar_access_token.value
-  basicauth_username                 = data.aws_ssm_parameter.basic_auth_username.value
-  basicauth_password                 = data.aws_ssm_parameter.basic_auth_password.value
-  basicauth_enabled                  = data.aws_ssm_parameter.basic_auth_enabled.value
-  products_import_bucket             = data.aws_ssm_parameter.products_import_bucket.value
+  basicauth_enabled                  = var.basic_auth_enabled
+  products_import_bucket             = module.s3.s3_product_import_name
   rollbar_env                        = var.rollbar_env
   redis_url                          = module.memcached.redis_url
   security_groups                    = [aws_security_group.spree.id]
@@ -595,22 +565,36 @@ module "sidekiq" {
   elasticsearch_url                  = "https://${data.aws_ssm_parameter.elasticsearch_url.value}:443"
   buyer_ui_url                       = "https://${data.aws_ssm_parameter.hosted_zone_name_cdn_bat_client.value}"
   app_domain                         = data.aws_ssm_parameter.hosted_zone_name_cdn_bat_backend.value
-  logit_hostname                     = data.aws_ssm_parameter.logit_hostname.value
-  logit_remote_port                  = data.aws_ssm_parameter.logit_remote_port.value
-  suppliers_sftp_bucket              = data.aws_ssm_parameter.suppliers_sftp_bucket.value
+  suppliers_sftp_bucket              = local.suppliers_sftp_bucket
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  lograge_enabled                    = data.aws_ssm_parameter.lograge_enabled.value
-  sendgrid_api_key                   = data.aws_ssm_parameter.sendgrid_api_key.value
-  mail_from                          = data.aws_ssm_parameter.mail_from.value
-  sidekiq_concurrency                = data.aws_ssm_parameter.sidekiq_concurrency.value
-  sidekiq_concurrency_searchkick     = data.aws_ssm_parameter.sidekiq_concurrency_searchkick.value
-  elasticsearch_limit                = data.aws_ssm_parameter.elasticsearch_limit.value
-  cnet_ftp_endpoint                  = data.aws_ssm_parameter.cnet_ftp_endpoint.value
-  cnet_ftp_port                      = data.aws_ssm_parameter.cnet_ftp_port.value
-  cnet_ftp_username                  = data.aws_ssm_parameter.cnet_ftp_username.value
-  cnet_ftp_password                  = data.aws_ssm_parameter.cnet_ftp_password.value
+  lograge_enabled                    = var.lograge_enabled
+  mail_from                          = var.email_from
+  sidekiq_concurrency                = var.sidekiq_concurrency
+  sidekiq_concurrency_searchkick     = var.sidekiq_concurrency_searchkick
+  elasticsearch_limit                = var.elasticsearch_limit
+  cnet_ftp_endpoint                  = var.cnet_ftp_endpoint
+  cnet_ftp_port                      = var.cnet_ftp_port
   default_country_id                 = var.default_country_id
+  # Secrets
+  aws_access_key_id_ssm_arn     = data.aws_ssm_parameter.aws_access_key_id.arn
+  aws_secret_access_key_ssm_arn = data.aws_ssm_parameter.aws_secret_access_key.arn
+  basicauth_username_ssm_arn    = data.aws_ssm_parameter.basic_auth_username.arn
+  basicauth_password_ssm_arn    = data.aws_ssm_parameter.basic_auth_password.arn
+  cnet_ftp_username_ssm_arn     = data.aws_ssm_parameter.cnet_ftp_username.arn
+  cnet_ftp_password_ssm_arn     = data.aws_ssm_parameter.cnet_ftp_password.arn
+  db_username_ssm_arn           = data.aws_ssm_parameter.spree_db_username.arn
+  db_password_ssm_arn           = data.aws_ssm_parameter.spree_db_password.arn
+  logit_hostname_ssm_arn        = data.aws_ssm_parameter.logit_hostname.arn
+  logit_remote_port_ssm_arn     = data.aws_ssm_parameter.logit_remote_port.arn
+  new_relic_license_key_ssm_arn = data.aws_ssm_parameter.new_relic_license_key.arn
+  rollbar_access_token_ssm_arn  = data.aws_ssm_parameter.rollbar_access_token.arn
+  secret_key_base_ssm_arn       = data.aws_ssm_parameter.secret_key_base.arn
+  sendgrid_username_ssm_arn     = data.aws_ssm_parameter.sendgrid_username.arn
+  sendgrid_password_ssm_arn     = data.aws_ssm_parameter.sendgrid_password.arn
+  sendgrid_api_key_ssm_arn      = data.aws_ssm_parameter.sendgrid_api_key.arn
+  sidekiq_username_ssm_arn      = data.aws_ssm_parameter.sidekiq_username.arn
+  sidekiq_password_ssm_arn      = data.aws_ssm_parameter.sidekiq_password.arn
 }
 
 ######################################
@@ -618,41 +602,42 @@ module "sidekiq" {
 ######################################
 
 module "client" {
-  source                             = "../../services/client"
-  environment                        = var.environment
-  vpc_id                             = data.aws_ssm_parameter.vpc_id.value
-  ecs_cluster_id                     = module.ecs_client.ecs_cluster_id
-  lb_public_alb_arn                  = data.aws_ssm_parameter.lb_public_alb_arn.value
-  hosted_zone_name                   = data.aws_ssm_parameter.hosted_zone_name_alb_bat_client.value
-  public_web_subnet_ids              = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
-  execution_role_arn                 = aws_iam_role.ecs_task_execution_role.arn
-  client_app_port                    = "8080" //8080
-  client_app_host                    = "0.0.0.0"
-  cpu                                = var.client_cpu
-  memory                             = var.client_memory
-  aws_region                         = local.aws_region
-  rollbar_access_token               = data.aws_ssm_parameter.rollbar_access_token.value
-  basicauth_username                 = data.aws_ssm_parameter.basic_auth_username.value
-  basicauth_password                 = data.aws_ssm_parameter.basic_auth_password.value
-  basicauth_enabled                  = data.aws_ssm_parameter.basic_auth_enabled.value
-  client_session_secret              = data.aws_ssm_parameter.client_session_secret.value
-  security_groups                    = [aws_security_group.client.id]
-  env_file                           = module.s3.env_file_client
-  cloudfront_id                      = data.aws_ssm_parameter.bat_client_cloudfront_id.value
-  spree_api_host                     = "http://${data.aws_ssm_parameter.lb_private_dns.value}"
-  spree_image_host                   = "https://${data.aws_ssm_parameter.hosted_zone_name_cdn_bat_backend.value}"
-  rollbar_env                        = var.rollbar_env
-  ecr_image_id_client                = var.ecr_image_id_client
-  logit_hostname                     = data.aws_ssm_parameter.logit_hostname.value
-  logit_remote_port                  = data.aws_ssm_parameter.logit_remote_port.value
-  documents_terms_and_conditions_url = data.aws_ssm_parameter.documents_terms_and_conditions_url.value
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  logit_node                         = data.aws_ssm_parameter.logit_node.value
-  browser_rollbar_access_token       = data.aws_ssm_parameter.browser_rollbar_access_token.value
-  enable_basket                      = data.aws_ssm_parameter.enable_basket.value
-  enable_quotes                      = data.aws_ssm_parameter.enable_quotes.value
-  logit_application                  = data.aws_ssm_parameter.logit_application.value
+  source                               = "../../services/client"
+  environment                          = var.environment
+  vpc_id                               = data.aws_ssm_parameter.vpc_id.value
+  ecs_cluster_id                       = module.ecs_client.ecs_cluster_id
+  lb_public_alb_arn                    = data.aws_ssm_parameter.lb_public_alb_arn.value
+  hosted_zone_name                     = data.aws_ssm_parameter.hosted_zone_name_alb_bat_client.value
+  public_web_subnet_ids                = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
+  execution_role_arn                   = aws_iam_role.ecs_task_execution_role.arn
+  client_app_port                      = "8080" //8080
+  client_app_host                      = "0.0.0.0"
+  cpu                                  = var.client_cpu
+  memory                               = var.client_memory
+  aws_region                           = local.aws_region
+  basicauth_enabled                    = var.basic_auth_enabled
+  security_groups                      = [aws_security_group.client.id]
+  cloudfront_id                        = data.aws_ssm_parameter.bat_client_cloudfront_id.value
+  spree_api_host                       = "http://${data.aws_ssm_parameter.lb_private_dns.value}"
+  spree_image_host                     = "https://${data.aws_ssm_parameter.hosted_zone_name_cdn_bat_backend.value}"
+  rollbar_env                          = var.rollbar_env
+  ecr_image_id_client                  = var.ecr_image_id_client
+  documents_terms_and_conditions_url   = var.documents_terms_and_conditions_url
+  deployment_maximum_percent           = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent   = var.deployment_minimum_healthy_percent
+  enable_basket                        = var.enable_basket
+  enable_quotes                        = var.enable_quotes
+  logit_application                    = var.logit_application == null ? "BAT-Buyer-UI-${upper(var.environment)}" : var.logit_application
+  error_pages_unknonwn_server_endpoint = var.error_pages_unknonwn_server_endpoint
+  # Secrets
+  browser_rollbar_access_token_ssm_arn = data.aws_ssm_parameter.browser_rollbar_access_token.arn
+  rollbar_access_token_ssm_arn         = data.aws_ssm_parameter.rollbar_access_token.arn
+  basicauth_username_ssm_arn           = data.aws_ssm_parameter.basic_auth_username.arn
+  basicauth_password_ssm_arn           = data.aws_ssm_parameter.basic_auth_password.arn
+  client_session_secret_ssm_arn        = data.aws_ssm_parameter.client_session_secret.arn
+  logit_hostname_ssm_arn               = data.aws_ssm_parameter.logit_hostname.arn
+  logit_remote_port_ssm_arn            = data.aws_ssm_parameter.logit_remote_port.arn
+  logit_node_ssm_arn                   = data.aws_ssm_parameter.logit_node.arn
 }
 
 ######################################

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -6,38 +6,31 @@ variable "environment" {
   type = string
 }
 
-variable "stage" {
-  type    = string
-  default = "staging"
+variable "az_names" {
+  type    = list(string)
+  default = ["eu-west-2a", "eu-west-2b"]
 }
 
-variable "api_rate_limit" {
-  type    = number
-  default = 10000
+#######################
+# SPREE SHARED
+#######################
+# (used to be param: //bar/{env}-basic-auth-enabled)
+variable "basic_auth_enabled" {
+  type    = bool
+  default = true
 }
 
-variable "api_burst_limit" {
-  type    = number
-  default = 5000
-}
-
-variable "ecr_image_id_spree" {
-  type    = string
-  default = "latest"
-}
-
+#######################
+# SPREE CLIENT
+#######################
 variable "ecr_image_id_client" {
   type    = string
   default = "latest"
 }
 
-variable "ecr_image_id_s3_virus_scan" {
+variable "client_ec2_instance_type" {
   type    = string
-  default = "latest"
-}
-
-variable "rollbar_env" {
-  type = string
+  default = "t2.medium"
 }
 
 variable "default_country_id" {
@@ -55,6 +48,61 @@ variable "client_memory" {
   default = 4096
 }
 
+# (used to be param: /bat/{env}-documents-terms-and-conditions-url)
+variable "documents_terms_and_conditions_url" {
+  type    = string
+  default = "https://www.crowncommercial.gov.uk/agreements/RM6147"
+}
+
+# (used to be param: /bat/{env}-enable-quotes)
+variable "enable_quotes" {
+  type    = bool
+  default = true
+}
+
+# (used to be param: /bat/{env}-enable-basket)
+variable "enable_basket" {
+  type    = bool
+  default = true
+}
+
+# (used to be param: /bat/{env}-sidekiq-concurrency)
+variable "sidekiq_concurrency" {
+  type    = number
+  default = 100
+}
+
+# (used to be param: /bat/{env}-sidekiq-concurrency-searchkick)
+variable "sidekiq_concurrency_searchkick" {
+  type    = number
+  default = 40
+}
+
+# (used to be param: /bat/{env}-logit-application)
+variable "logit_application" {
+  type    = string
+  default = null # this is purposfully null as we do a null check in the main.tf
+}
+
+# (used to be env var: ERROR_PAGES_EXPOSE_UNKNOWN_SERVER_ERROR_ENDPOINT)
+variable "error_pages_unknonwn_server_endpoint" {
+  type    = bool
+  default = false
+}
+
+#######################
+# SPREE BACKEND
+#######################
+variable "ecr_image_id_spree" {
+  type    = string
+  default = "latest"
+}
+
+variable "spree_ec2_instance_type" {
+  type    = string
+  default = "t2.xlarge"
+}
+
 variable "spree_cpu" {
   type    = number
   default = 4096
@@ -63,6 +111,56 @@ variable "spree_cpu" {
 variable "spree_memory" {
   type    = number
   default = 8192
+}
+
+# (used to be param: /bat/{env}-elasticsearch-limit)
+variable "elasticsearch_limit" {
+  type    = number
+  default = 12
+}
+
+# (used to be param: /bat/{env}-mail-from)
+variable "email_from" {
+  type    = string
+  default = "bt@sprks.eu"
+}
+
+# (used to be param: /bat/{env}-cnet-ftp-endpoint)
+variable "cnet_ftp_endpoint" {
+  type    = string
+  default = "ftp.cnetcontentsolutions.com"
+}
+
+# (used to be param: /bat/{env}-cnet-ftp-port)
+variable "cnet_ftp_port" {
+  type    = number
+  default = 21
+}
+
+# (used to be param: /bat/{env}-lograge-enabled)
+variable "lograge_enabled" {
+  type    = bool
+  default = true
+}
+
+# (used to be env var: NEW_RELIC_APP_NAME from spree.env)
+variable "new_relic_app_name" {
+  type    = string
+  default = null # this is purposfully null as we do a null check in the main.tf
+}
+
+# (used to be env var: NEW_RELIC_AGENT_ENABLED from spree.env)
+variable "new_relic_agent_enabled" {
+  type    = bool
+  default = true
+}
+
+#######################
+# SPREE SIDEKIQ
+#######################
+variable "sidekiq_ec2_instance_type" {
+  type    = string
+  default = "t2.xlarge"
 }
 
 variable "sidekiq_cpu" {
@@ -75,81 +173,32 @@ variable "sidekiq_memory" {
   default = 8192
 }
 
-# TODO: Has this been specified?
-variable "s3_virus_scan_cpu" {
-  type    = number
-  default = 4096
+#######################
+# ROLLBAR
+#######################
+variable "rollbar_env" {
+  type = string
 }
 
-# TODO: Has this been specified?
-variable "s3_virus_scan_memory" {
-  type    = number
-  default = 8192
-}
-
-variable "client_ec2_instance_type" {
-  type    = string
-  default = "t2.medium"
-}
-
-# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now)
-variable "spree_ec2_instance_type" {
-  type    = string
-  default = "t2.xlarge"
-}
-
-# TODO: Confirm with Som - there is no t2 instance matching 4/8 split on spreadsheet (set to 4/16 t2.xlarge for now)
-variable "sidekiq_ec2_instance_type" {
-  type    = string
-  default = "t2.xlarge"
-}
-
-# TODO: Has this been specified?
-variable "s3_virus_scan_ec2_instance_type" {
-  type    = string
-  default = "t2.xlarge"
-}
-
+#######################
+# MEMCACHED
+#######################
 variable "memcached_node_type" {
   type    = string
   default = "cache.t3.medium"
 }
 
+#######################
+# REDIS
+#######################
 variable "redis_node_type" {
   type    = string
   default = "cache.t3.medium"
 }
 
-variable "deployment_maximum_percent" {
-  type    = number
-  default = 100
-}
-
-variable "deployment_minimum_healthy_percent" {
-  type    = number
-  default = 50
-}
-
-variable "az_names" {
-  type    = list(string)
-  default = ["eu-west-2a", "eu-west-2b"]
-}
-
-variable "ecr_image_id_catalogue" {
-  type    = string
-  default = "616acaf-candidate"
-}
-
-variable "catalogue_cpu" {
-  type    = number
-  default = 512
-}
-
-variable "catalogue_memory" {
-  type    = number
-  default = 1024
-}
-
+#######################
+# AUTH SERVICE
+#######################
 variable "ecr_image_id_auth" {
   type    = string
   default = "d1d128d-candidate"
@@ -165,9 +214,84 @@ variable "auth_memory" {
   default = 1024
 }
 
+#######################
+# CATALOGUE SERVICE
+#######################
+variable "ecr_image_id_catalogue" {
+  type    = string
+  default = "616acaf-candidate"
+}
+
+variable "catalogue_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "catalogue_memory" {
+  type    = number
+  default = 1024
+}
+
+#######################
+# S3 VIRUS SCAN SERVICE
+#######################
+variable "ecr_image_id_s3_virus_scan" {
+  type    = string
+  default = "latest"
+}
+
+# TODO: Has this been specified?
+variable "s3_virus_scan_ec2_instance_type" {
+  type    = string
+  default = "t2.xlarge"
+}
+
+# TODO: Has this been specified?
+variable "s3_virus_scan_cpu" {
+  type    = number
+  default = 4096
+}
+
+# TODO: Has this been specified?
+variable "s3_virus_scan_memory" {
+  type    = number
+  default = 8192
+}
+
+#######################
+# BAT API GATEWAY
+#######################
+variable "stage" {
+  type    = string
+  default = "staging"
+}
+
+variable "api_rate_limit" {
+  type    = number
+  default = 10000
+}
+
+variable "api_burst_limit" {
+  type    = number
+  default = 5000
+}
+
 variable "api_gw_log_retention_in_days" {
   type    = number
   default = 7
+}
+
+#######################
+# ECS
+#######################
+variable "deployment_maximum_percent" {
+  type    = number
+  default = 100
+}
+
+variable "deployment_minimum_healthy_percent" {
+  type    = number
+  default = 50
 }
 
 variable "ecs_log_retention_in_days" {

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -15,6 +15,10 @@ resource "aws_s3_bucket" "static" {
   tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
+# Deprecated (as of SINF-356) - this bucket is no longer needed.
+# Leaving for now, as these buckets contain .env files which have info that
+# may be needed for a short while after transition to system param approach.
+# To be removed as part of follow up task SINF-371
 resource "aws_s3_bucket" "system" {
   bucket        = "system-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = true
@@ -39,14 +43,6 @@ resource "aws_s3_bucket" "cnet" {
 resource "aws_s3_bucket_object" "env-spree" {
   bucket = aws_s3_bucket.system.id
   key    = "spree.env"
-  acl    = "private"
-
-  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
-}
-
-resource "aws_s3_bucket_object" "env-client" {
-  bucket = aws_s3_bucket.system.id
-  key    = "client.env"
   acl    = "private"
 
   tags = merge(module.globals.project_resource_tags, { AppType = "S3" })

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,11 +1,11 @@
-output "env_file_client" {
-  value = "${aws_s3_bucket.system.arn}/${aws_s3_bucket_object.env-client.id}"
-}
-
 output "env_file_spree" {
   value = "${aws_s3_bucket.system.arn}/${aws_s3_bucket_object.env-spree.id}"
 }
 
 output "s3_static_bucket_name" {
   value = aws_s3_bucket.static.id
+}
+
+output "s3_product_import_name" {
+  value = aws_s3_bucket.product-import.id
 }

--- a/terraform/modules/services/client/client.json.tpl
+++ b/terraform/modules/services/client/client.json.tpl
@@ -13,10 +13,38 @@
           "awslogs-stream-prefix": "ecs"
         }
     },
-    "environmentFiles": [
+    "secrets": [
       {
-        "type": "s3",
-        "value": "${env_file}"
+        "name": "BASICAUTH_USERNAME",
+        "valueFrom": "${basicauth_username_ssm_arn}"
+      },
+      {
+        "name": "BASICAUTH_PASSWORD",
+        "valueFrom": "${basicauth_password_ssm_arn}"
+      },
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "valueFrom": "${rollbar_access_token_ssm_arn}"
+      },
+      {
+        "name": "BROWSER_ROLLBAR_ACCESS_TOKEN",
+        "valueFrom": "${browser_rollbar_access_token_ssm_arn}"
+      },
+      {
+        "name": "SESSION_COOKIE_SECRET",
+        "valueFrom": "${client_session_secret_ssm_arn}"
+      },
+      {
+        "name": "LOGIT_HOSTNAME",
+        "valueFrom": "${logit_hostname_ssm_arn}"
+      },
+      {
+        "name": "LOGIT_REMOTE_PORT",
+        "valueFrom": "${logit_remote_port_ssm_arn}"
+      },
+      {
+        "name": "LOGIT_NODE",
+        "valueFrom": "${logit_node_ssm_arn}"
       }
     ],
     "environment": [
@@ -29,28 +57,12 @@
         "value": "${app_port}"
       },
       {
-        "name": "ROLLBAR_ACCESS_TOKEN",
-        "value": "${rollbar_access_token}"
-      },
-      {
-        "name": "BASICAUTH_USERNAME",
-        "value": "${basicauth_username}"
-      },
-      {
-        "name": "BASICAUTH_PASSWORD",
-        "value": "${basicauth_password}"
-      },
-      {
         "name": "BASICAUTH_ENABLED",
         "value": "${basicauth_enabled}"
       },
       {
         "name": "SPREE_API_HOST",
         "value": "${spree_api_host}"
-      },
-      {
-        "name": "SESSION_COOKIE_SECRET",
-        "value": "${client_session_secret}"
       },
       {
         "name": "ROLLBAR_ENV",
@@ -65,24 +77,8 @@
         "value": "${spree_api_host}"
       },
       {
-        "name": "LOGIT_HOSTNAME",
-        "value": "${logit_hostname}"
-      },
-      {
-        "name": "LOGIT_REMOTE_PORT",
-        "value": "${logit_remote_port}"
-      },
-      {
         "name": "DOCUMENTS_TERMS_AND_CONDITIONS_URL",
         "value": "${documents_terms_and_conditions_url}"
-      },
-      {
-        "name": "LOGIT_NODE",
-        "value": "${logit_node}"
-      },
-      {
-        "name": "BROWSER_ROLLBAR_ACCESS_TOKEN",
-        "value": "${browser_rollbar_access_token}"
       },
       {
         "name": "ENABLE_BASKET",
@@ -95,6 +91,10 @@
       {
         "name": "LOGIT_APPLICATION",
         "value": "${logit_application}"
+      },
+      {
+        "name": "ERROR_PAGES_EXPOSE_UNKNOWN_SERVER_ERROR_ENDPOINT",
+        "value": "${error_pages_unknonwn_server_endpoint}"
       }
     ],
     "command": [

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -81,30 +81,32 @@ data "template_file" "app_client" {
   template = file("${path.module}/client.json.tpl")
 
   vars = {
-    app_image                          = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/bat-buyer-ui-staging:${var.ecr_image_id_client}"
-    app_port                           = var.client_app_port
-    cpu                                = var.cpu
-    memory                             = var.memory
-    aws_region                         = var.aws_region
-    name                               = "client-app-task"
-    api_host                           = var.client_app_host
-    spree_api_host                     = var.spree_api_host
-    spree_image_host                   = var.spree_image_host
-    rollbar_access_token               = var.rollbar_access_token
-    basicauth_username                 = var.basicauth_username
-    basicauth_password                 = var.basicauth_password
-    basicauth_enabled                  = var.basicauth_enabled
-    rollbar_env                        = var.rollbar_env
-    env_file                           = var.env_file
-    client_session_secret              = var.client_session_secret
-    logit_hostname                     = var.logit_hostname
-    logit_remote_port                  = var.logit_remote_port
-    documents_terms_and_conditions_url = var.documents_terms_and_conditions_url
-    logit_node                         = var.logit_node
-    browser_rollbar_access_token       = var.browser_rollbar_access_token
-    enable_basket                      = var.enable_basket
-    enable_quotes                      = var.enable_quotes
-    logit_application                  = var.logit_application
+    app_image                            = "${module.globals.env_accounts["mgmt"]}.dkr.ecr.eu-west-2.amazonaws.com/scale/bat-buyer-ui-staging:${var.ecr_image_id_client}"
+    app_port                             = var.client_app_port
+    cpu                                  = var.cpu
+    memory                               = var.memory
+    aws_region                           = var.aws_region
+    name                                 = "client-app-task"
+    api_host                             = var.client_app_host
+    spree_api_host                       = var.spree_api_host
+    spree_image_host                     = var.spree_image_host
+    basicauth_enabled                    = var.basicauth_enabled
+    rollbar_env                          = var.rollbar_env
+    documents_terms_and_conditions_url   = var.documents_terms_and_conditions_url
+    enable_basket                        = var.enable_basket
+    enable_quotes                        = var.enable_quotes
+    logit_application                    = var.logit_application
+    error_pages_unknonwn_server_endpoint = var.error_pages_unknonwn_server_endpoint
+
+    # Secrets
+    browser_rollbar_access_token_ssm_arn = var.browser_rollbar_access_token_ssm_arn
+    client_session_secret_ssm_arn        = var.client_session_secret_ssm_arn
+    rollbar_access_token_ssm_arn         = var.rollbar_access_token_ssm_arn
+    basicauth_username_ssm_arn           = var.basicauth_username_ssm_arn
+    basicauth_password_ssm_arn           = var.basicauth_password_ssm_arn
+    logit_hostname_ssm_arn               = var.logit_hostname_ssm_arn
+    logit_remote_port_ssm_arn            = var.logit_remote_port_ssm_arn
+    logit_node_ssm_arn                   = var.logit_node_ssm_arn
   }
 }
 

--- a/terraform/modules/services/client/variables.tf
+++ b/terraform/modules/services/client/variables.tf
@@ -11,10 +11,6 @@ variable "ecs_cluster_id" {
   type = string
 }
 
-#variable "lb_public_arn" {
-#  type = string
-#}
-
 variable "lb_public_alb_arn" {
   type = string
 }
@@ -47,23 +43,7 @@ variable "spree_api_host" {
   type = string
 }
 
-variable "rollbar_access_token" {
-  type = string
-}
-
-variable "basicauth_username" {
-  type = string
-}
-
-variable "basicauth_password" {
-  type = string
-}
-
 variable "basicauth_enabled" {
-  type = string
-}
-
-variable "client_session_secret" {
   type = string
 }
 
@@ -83,23 +63,11 @@ variable "security_groups" {
   type = list(string)
 }
 
-variable "env_file" {
-  type = string
-}
-
 variable "cloudfront_id" {
   type = string
 }
 
 variable "ecr_image_id_client" {
-  type = string
-}
-
-variable "logit_hostname" {
-  type = string
-}
-
-variable "logit_remote_port" {
   type = string
 }
 
@@ -119,14 +87,6 @@ variable "deployment_minimum_healthy_percent" {
   type = number
 }
 
-variable "logit_node" {
-  type = string
-}
-
-variable "browser_rollbar_access_token" {
-  type = string
-}
-
 variable "enable_basket" {
   type = string
 }
@@ -136,5 +96,44 @@ variable "enable_quotes" {
 }
 
 variable "logit_application" {
+  type = string
+}
+
+variable "error_pages_unknonwn_server_endpoint" {
+  type = string
+}
+
+#########
+# Secrets
+#########
+variable "rollbar_access_token_ssm_arn" {
+  type = string
+}
+
+variable "basicauth_username_ssm_arn" {
+  type = string
+}
+
+variable "basicauth_password_ssm_arn" {
+  type = string
+}
+
+variable "client_session_secret_ssm_arn" {
+  type = string
+}
+
+variable "browser_rollbar_access_token_ssm_arn" {
+  type = string
+}
+
+variable "logit_hostname_ssm_arn" {
+  type = string
+}
+
+variable "logit_remote_port_ssm_arn" {
+  type = string
+}
+
+variable "logit_node_ssm_arn" {
   type = string
 }

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -16,13 +16,7 @@ data "template_file" "app_sidekiq" {
     name                           = "sidekiq-task"
     db_name                        = var.db_name
     db_host                        = var.db_host
-    db_username                    = var.db_username
-    db_password                    = var.db_password
-    secret_key_base                = var.secret_key_base
-    basicauth_username             = var.basicauth_username
-    basicauth_password             = var.basicauth_password
     basicauth_enabled              = var.basicauth_enabled
-    rollbar_spree_access_token     = var.rollbar_access_token
     products_import_bucket         = var.products_import_bucket
     rollbar_env                    = var.rollbar_env
     env_file                       = var.env_file
@@ -30,20 +24,35 @@ data "template_file" "app_sidekiq" {
     elasticsearch_url              = var.elasticsearch_url
     buyer_ui_url                   = var.buyer_ui_url
     app_domain                     = var.app_domain
-    logit_hostname                 = var.logit_hostname
-    logit_remote_port              = var.logit_remote_port
     suppliers_sftp_bucket          = var.suppliers_sftp_bucket
     lograge_enabled                = var.lograge_enabled
-    sendgrid_api_key               = var.sendgrid_api_key
     mail_from                      = var.mail_from
     sidekiq_concurrency            = var.sidekiq_concurrency
     sidekiq_concurrency_searchkick = var.sidekiq_concurrency_searchkick
     elasticsearch_limit            = var.elasticsearch_limit
     cnet_ftp_endpoint              = var.cnet_ftp_endpoint
     cnet_ftp_port                  = var.cnet_ftp_port
-    cnet_ftp_username              = var.cnet_ftp_username
-    cnet_ftp_password              = var.cnet_ftp_password
     default_country_id             = var.default_country_id
+
+    # Secrets
+    db_username_ssm_arn           = var.db_username_ssm_arn
+    db_password_ssm_arn           = var.db_password_ssm_arn
+    secret_key_base_ssm_arn       = var.secret_key_base_ssm_arn
+    basicauth_username_ssm_arn    = var.basicauth_username_ssm_arn
+    basicauth_password_ssm_arn    = var.basicauth_password_ssm_arn
+    rollbar_access_token_ssm_arn  = var.rollbar_access_token_ssm_arn
+    cnet_ftp_username_ssm_arn     = var.cnet_ftp_username_ssm_arn
+    cnet_ftp_password_ssm_arn     = var.cnet_ftp_password_ssm_arn
+    sidekiq_username_ssm_arn      = var.sidekiq_username_ssm_arn
+    sidekiq_password_ssm_arn      = var.sidekiq_password_ssm_arn
+    sendgrid_username_ssm_arn     = var.sendgrid_username_ssm_arn
+    sendgrid_password_ssm_arn     = var.sendgrid_password_ssm_arn
+    sendgrid_api_key_ssm_arn      = var.sendgrid_api_key_ssm_arn
+    aws_access_key_id_ssm_arn     = var.aws_access_key_id_ssm_arn
+    aws_secret_access_key_ssm_arn = var.aws_secret_access_key_ssm_arn
+    new_relic_license_key_ssm_arn = var.new_relic_license_key_ssm_arn
+    logit_hostname_ssm_arn        = var.logit_hostname_ssm_arn
+    logit_remote_port_ssm_arn     = var.logit_remote_port_ssm_arn
   }
 }
 

--- a/terraform/modules/services/sidekiq/sidekiq.json.tpl
+++ b/terraform/modules/services/sidekiq/sidekiq.json.tpl
@@ -13,10 +13,78 @@
           "awslogs-stream-prefix": "ecs"
         }
     },
-    "environmentFiles": [
+    "secrets": [
       {
-        "type": "s3",
-        "value": "${env_file}"
+        "name": "BASICAUTH_USERNAME",
+        "valueFrom": "${basicauth_username_ssm_arn}"
+      },
+      {
+        "name": "BASICAUTH_PASSWORD",
+        "valueFrom": "${basicauth_password_ssm_arn}"
+      },
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "valueFrom": "${rollbar_access_token_ssm_arn}"
+      },
+      {
+        "name": "DB_USERNAME",
+        "valueFrom": "${db_username_ssm_arn}"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "valueFrom": "${db_password_ssm_arn}"
+      },
+      {
+        "name": "SENDGRID_API_KEY",
+        "valueFrom": "${sendgrid_api_key_ssm_arn}"
+      },
+      {
+        "name": "CNET_FTP_USERNAME",
+        "valueFrom": "${cnet_ftp_username_ssm_arn}"
+      },
+      {
+        "name": "CNET_FTP_PASSWORD",
+        "valueFrom": "${cnet_ftp_password_ssm_arn}"
+      },
+      {
+        "name": "SECRET_KEY_BASE",
+        "valueFrom": "${secret_key_base_ssm_arn}"
+      },
+      {
+        "name": "LOGIT_HOSTNAME",
+        "valueFrom": "${logit_hostname_ssm_arn}"
+      },
+      {
+        "name": "LOGIT_REMOTE_PORT",
+        "valueFrom": "${logit_remote_port_ssm_arn}"
+      },
+      {
+        "name": "NEW_RELIC_LICENSE_KEY",
+        "valueFrom": "${new_relic_license_key_ssm_arn}"
+      },
+      {
+        "name": "SIDEKIQ_USERNAME",
+        "valueFrom": "${sidekiq_username_ssm_arn}"
+      },
+      {
+        "name": "SIDEKIQ_PASSWORD",
+        "valueFrom": "${sidekiq_password_ssm_arn}"
+      },
+      {
+        "name": "SENDGRID_USERNAME",
+        "valueFrom": "${sendgrid_username_ssm_arn}"
+      },
+      {
+        "name": "SENDGRID_PASSWORD",
+        "valueFrom": "${sendgrid_password_ssm_arn}"
+      },
+      {
+        "name": "AWS_ACCESS_KEY_ID",
+        "valueFrom": "${aws_access_key_id_ssm_arn}"
+      },
+      {
+        "name": "AWS_SECRET_ACCESS_KEY",
+        "valueFrom": "${aws_secret_access_key_ssm_arn}"
       }
     ],
     "environment": [
@@ -29,32 +97,8 @@
         "value": "${db_host}"
       },
       {
-        "name": "DB_USERNAME",
-        "value": "${db_username}"
-      },
-      {
-        "name": "DB_PASSWORD",
-        "value": "${db_password}"
-      },
-      {
-        "name": "SECRET_KEY_BASE",
-        "value": "${secret_key_base}"
-      },
-      {
-        "name": "BASICAUTH_USERNAME",
-        "value": "${basicauth_username}"
-      },
-      {
-        "name": "BASICAUTH_PASSWORD",
-        "value": "${basicauth_password}"
-      },
-      {
         "name": "BASICAUTH_ENABLED",
         "value": "${basicauth_enabled}"
-      },
-      {
-        "name": "ROLLBAR_ACCESS_TOKEN",
-        "value": "${rollbar_spree_access_token}"
       },
       {
         "name": "REDIS_URL",
@@ -89,20 +133,8 @@
         "value": "${suppliers_sftp_bucket}"
       },
       {
-        "name": "LOGIT_HOSTNAME",
-        "value": "${logit_hostname}"
-      },
-      {
-        "name": "LOGIT_REMOTE_PORT",
-        "value": "${logit_remote_port}"
-      },
-      {
         "name": "LOGRAGE_ENABLED",
         "value": "${lograge_enabled}"
-      },
-      {
-        "name": "SENDGRID_API_KEY",
-        "value": "${sendgrid_api_key}"
       },
       {
         "name": "MAIL_FROM",
@@ -127,15 +159,7 @@
       {
         "name": "CNET_FTP_PORT",
         "value": "${cnet_ftp_port}"
-      },
-      {
-        "name": "CNET_FTP_USERNAME",
-        "value": "${cnet_ftp_username}"
-      },
-      {
-        "name": "CNET_FTP_PASSWORD",
-        "value": "${cnet_ftp_password}"
-      },
+	  },
       {
         "name": "DEFAULT_COUNTRY_ID",
         "value": "${default_country_id}"

--- a/terraform/modules/services/sidekiq/variables.tf
+++ b/terraform/modules/services/sidekiq/variables.tf
@@ -42,30 +42,6 @@ variable "db_host" {
   type = string
 }
 
-variable "db_username" {
-  type = string
-}
-
-variable "db_password" {
-  type = string
-}
-
-variable "secret_key_base" {
-  type = string
-}
-
-variable "rollbar_access_token" {
-  type = string
-}
-
-variable "basicauth_username" {
-  type = string
-}
-
-variable "basicauth_password" {
-  type = string
-}
-
 variable "basicauth_enabled" {
   type = string
 }
@@ -106,14 +82,6 @@ variable "app_domain" {
   type = string
 }
 
-variable "logit_hostname" {
-  type = string
-}
-
-variable "logit_remote_port" {
-  type = string
-}
-
 variable "suppliers_sftp_bucket" {
   type = string
 }
@@ -127,10 +95,6 @@ variable "deployment_minimum_healthy_percent" {
 }
 
 variable "lograge_enabled" {
-  type = string
-}
-
-variable "sendgrid_api_key" {
   type = string
 }
 
@@ -158,11 +122,78 @@ variable "cnet_ftp_port" {
   type = string
 }
 
-variable "cnet_ftp_username" {
+#########
+# Secrets
+#########
+variable "aws_access_key_id_ssm_arn" {
   type = string
 }
 
-variable "cnet_ftp_password" {
+variable "aws_secret_access_key_ssm_arn" {
+  type = string
+}
+
+variable "basicauth_username_ssm_arn" {
+  type = string
+}
+
+variable "basicauth_password_ssm_arn" {
+  type = string
+}
+
+variable "cnet_ftp_username_ssm_arn" {
+  type = string
+}
+
+variable "db_username_ssm_arn" {
+  type = string
+}
+
+variable "db_password_ssm_arn" {
+  type = string
+}
+
+variable "logit_hostname_ssm_arn" {
+  type = string
+}
+
+variable "logit_remote_port_ssm_arn" {
+  type = string
+}
+
+variable "new_relic_license_key_ssm_arn" {
+  type = string
+}
+
+variable "rollbar_access_token_ssm_arn" {
+  type = string
+}
+
+variable "cnet_ftp_password_ssm_arn" {
+  type = string
+}
+
+variable "sidekiq_username_ssm_arn" {
+  type = string
+}
+
+variable "sidekiq_password_ssm_arn" {
+  type = string
+}
+
+variable "secret_key_base_ssm_arn" {
+  type = string
+}
+
+variable "sendgrid_username_ssm_arn" {
+  type = string
+}
+
+variable "sendgrid_password_ssm_arn" {
+  type = string
+}
+
+variable "sendgrid_api_key_ssm_arn" {
   type = string
 }
 

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -110,13 +110,7 @@ data "template_file" "app_client" {
     name                           = "spree-app-task"
     db_name                        = var.db_name
     db_host                        = var.db_host
-    db_username                    = var.db_username
-    db_password                    = var.db_password
-    secret_key_base                = var.secret_key_base
-    basicauth_username             = var.basicauth_username
-    basicauth_password             = var.basicauth_password
     basicauth_enabled              = var.basicauth_enabled
-    rollbar_spree_access_token     = var.rollbar_access_token
     products_import_bucket         = var.products_import_bucket
     rollbar_env                    = var.rollbar_env
     env_file                       = var.env_file
@@ -125,20 +119,38 @@ data "template_file" "app_client" {
     elasticsearch_url              = var.elasticsearch_url
     buyer_ui_url                   = var.buyer_ui_url
     app_domain                     = var.app_domain
-    logit_hostname                 = var.logit_hostname
-    logit_remote_port              = var.logit_remote_port
     suppliers_sftp_bucket          = var.suppliers_sftp_bucket
     lograge_enabled                = var.lograge_enabled
-    sendgrid_api_key               = var.sendgrid_api_key
     mail_from                      = var.mail_from
     sidekiq_concurrency            = var.sidekiq_concurrency
     sidekiq_concurrency_searchkick = var.sidekiq_concurrency_searchkick
     elasticsearch_limit            = var.elasticsearch_limit
     cnet_ftp_endpoint              = var.cnet_ftp_endpoint
     cnet_ftp_port                  = var.cnet_ftp_port
-    cnet_ftp_username              = var.cnet_ftp_username
-    cnet_ftp_password              = var.cnet_ftp_password
     default_country_id             = var.default_country_id
+    new_relic_app_name             = var.new_relic_app_name
+    new_relic_agent_enabled        = var.new_relic_agent_enabled
+    s3_static_bucket_name          = var.s3_static_bucket_name
+
+    # Secrets
+    db_username_ssm_arn           = var.db_username_ssm_arn
+    db_password_ssm_arn           = var.db_password_ssm_arn
+    secret_key_base_ssm_arn       = var.secret_key_base_ssm_arn
+    basicauth_username_ssm_arn    = var.basicauth_username_ssm_arn
+    basicauth_password_ssm_arn    = var.basicauth_password_ssm_arn
+    rollbar_access_token_ssm_arn  = var.rollbar_access_token_ssm_arn
+    cnet_ftp_username_ssm_arn     = var.cnet_ftp_username_ssm_arn
+    cnet_ftp_password_ssm_arn     = var.cnet_ftp_password_ssm_arn
+    sidekiq_username_ssm_arn      = var.sidekiq_username_ssm_arn
+    sidekiq_password_ssm_arn      = var.sidekiq_password_ssm_arn
+    sendgrid_username_ssm_arn     = var.sendgrid_username_ssm_arn
+    sendgrid_password_ssm_arn     = var.sendgrid_password_ssm_arn
+    sendgrid_api_key_ssm_arn      = var.sendgrid_api_key_ssm_arn
+    aws_access_key_id_ssm_arn     = var.aws_access_key_id_ssm_arn
+    aws_secret_access_key_ssm_arn = var.aws_secret_access_key_ssm_arn
+    new_relic_license_key_ssm_arn = var.new_relic_license_key_ssm_arn
+    logit_hostname_ssm_arn        = var.logit_hostname_ssm_arn
+    logit_remote_port_ssm_arn     = var.logit_remote_port_ssm_arn
   }
 }
 

--- a/terraform/modules/services/spree/spree.json.tpl
+++ b/terraform/modules/services/spree/spree.json.tpl
@@ -13,10 +13,78 @@
           "awslogs-stream-prefix": "ecs"
         }
     },
-    "environmentFiles": [
+    "secrets": [
       {
-        "type": "s3",
-        "value": "${env_file}"
+        "name": "BASICAUTH_USERNAME",
+        "valueFrom": "${basicauth_username_ssm_arn}"
+      },
+      {
+        "name": "BASICAUTH_PASSWORD",
+        "valueFrom": "${basicauth_password_ssm_arn}"
+      },
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "valueFrom": "${rollbar_access_token_ssm_arn}"
+      },
+      {
+        "name": "DB_USERNAME",
+        "valueFrom": "${db_username_ssm_arn}"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "valueFrom": "${db_password_ssm_arn}"
+      },
+      {
+        "name": "SENDGRID_API_KEY",
+        "valueFrom": "${sendgrid_api_key_ssm_arn}"
+      },
+      {
+        "name": "CNET_FTP_USERNAME",
+        "valueFrom": "${cnet_ftp_username_ssm_arn}"
+      },
+      {
+        "name": "CNET_FTP_PASSWORD",
+        "valueFrom": "${cnet_ftp_password_ssm_arn}"
+      },
+      {
+        "name": "SECRET_KEY_BASE",
+        "valueFrom": "${secret_key_base_ssm_arn}"
+      },
+      {
+        "name": "LOGIT_HOSTNAME",
+        "valueFrom": "${logit_hostname_ssm_arn}"
+      },
+      {
+        "name": "LOGIT_REMOTE_PORT",
+        "valueFrom": "${logit_remote_port_ssm_arn}"
+      },
+      {
+        "name": "NEW_RELIC_LICENSE_KEY",
+        "valueFrom": "${new_relic_license_key_ssm_arn}"
+      },
+      {
+        "name": "SIDEKIQ_USERNAME",
+        "valueFrom": "${sidekiq_username_ssm_arn}"
+      },
+      {
+        "name": "SIDEKIQ_PASSWORD",
+        "valueFrom": "${sidekiq_password_ssm_arn}"
+      },
+      {
+        "name": "SENDGRID_USERNAME",
+        "valueFrom": "${sendgrid_username_ssm_arn}"
+      },
+      {
+        "name": "SENDGRID_PASSWORD",
+        "valueFrom": "${sendgrid_password_ssm_arn}"
+      },
+      {
+        "name": "AWS_ACCESS_KEY_ID",
+        "valueFrom": "${aws_access_key_id_ssm_arn}"
+      },
+      {
+        "name": "AWS_SECRET_ACCESS_KEY",
+        "valueFrom": "${aws_secret_access_key_ssm_arn}"
       }
     ],
     "environment": [
@@ -29,32 +97,8 @@
         "value": "${db_host}"
       },
       {
-        "name": "DB_USERNAME",
-        "value": "${db_username}"
-      },
-      {
-        "name": "DB_PASSWORD",
-        "value": "${db_password}"
-      },
-      {
-        "name": "SECRET_KEY_BASE",
-        "value": "${secret_key_base}"
-      },
-      {
-        "name": "BASICAUTH_USERNAME",
-        "value": "${basicauth_username}"
-      },
-      {
-        "name": "BASICAUTH_PASSWORD",
-        "value": "${basicauth_password}"
-      },
-      {
         "name": "BASICAUTH_ENABLED",
         "value": "${basicauth_enabled}"
-      },
-      {
-        "name": "ROLLBAR_ACCESS_TOKEN",
-        "value": "${rollbar_spree_access_token}"
       },
       {
         "name": "REDIS_URL",
@@ -93,20 +137,8 @@
         "value": "${suppliers_sftp_bucket}"
       },
       {
-        "name": "LOGIT_HOSTNAME",
-        "value": "${logit_hostname}"
-      },
-      {
-        "name": "LOGIT_REMOTE_PORT",
-        "value": "${logit_remote_port}"
-      },
-      {
         "name": "LOGRAGE_ENABLED",
         "value": "${lograge_enabled}"
-      },
-      {
-        "name": "SENDGRID_API_KEY",
-        "value": "${sendgrid_api_key}"
       },
       {
         "name": "MAIL_FROM",
@@ -133,17 +165,25 @@
         "value": "${cnet_ftp_port}"
       },
       {
-        "name": "CNET_FTP_USERNAME",
-        "value": "${cnet_ftp_username}"
+        "name": "S3_REGION",
+        "value": "${aws_region}"
       },
       {
-        "name": "CNET_FTP_PASSWORD",
-        "value": "${cnet_ftp_password}"
+        "name": "S3_BUCKET_NAME",
+        "value": "${s3_static_bucket_name}"
+      },
+      {
+        "name": "NEW_RELIC_APP_NAME",
+        "value": "${new_relic_app_name}"
+      },
+      {
+        "name": "NEW_RELIC_AGENT_ENABLED",
+        "value": "${new_relic_agent_enabled}"
       },
       {
         "name": "DEFAULT_COUNTRY_ID",
         "value": "${default_country_id}"
-      }
+	  }
     ],
     "command": [
       "bundle", "exec", "rails","s","-b","0.0.0.0","-p", "${app_port}"

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -50,30 +50,6 @@ variable "db_host" {
   type = string
 }
 
-variable "db_username" {
-  type = string
-}
-
-variable "db_password" {
-  type = string
-}
-
-variable "secret_key_base" {
-  type = string
-}
-
-variable "rollbar_access_token" {
-  type = string
-}
-
-variable "basicauth_username" {
-  type = string
-}
-
-variable "basicauth_password" {
-  type = string
-}
-
 variable "basicauth_enabled" {
   type = string
 }
@@ -122,14 +98,6 @@ variable "app_domain" {
   type = string
 }
 
-variable "logit_hostname" {
-  type = string
-}
-
-variable "logit_remote_port" {
-  type = string
-}
-
 variable "hosted_zone_name" {
   type = string
 }
@@ -147,10 +115,6 @@ variable "deployment_minimum_healthy_percent" {
 }
 
 variable "lograge_enabled" {
-  type = string
-}
-
-variable "sendgrid_api_key" {
   type = string
 }
 
@@ -178,11 +142,90 @@ variable "cnet_ftp_port" {
   type = string
 }
 
-variable "cnet_ftp_username" {
+variable "s3_static_bucket_name" {
   type = string
 }
 
-variable "cnet_ftp_password" {
+variable "new_relic_app_name" {
+  type = string
+}
+
+variable "new_relic_agent_enabled" {
+  type = string
+}
+
+#########
+# Secrets
+#########
+variable "aws_access_key_id_ssm_arn" {
+  type = string
+}
+
+variable "aws_secret_access_key_ssm_arn" {
+  type = string
+}
+
+variable "basicauth_username_ssm_arn" {
+  type = string
+}
+
+variable "basicauth_password_ssm_arn" {
+  type = string
+}
+
+variable "cnet_ftp_username_ssm_arn" {
+  type = string
+}
+
+variable "db_username_ssm_arn" {
+  type = string
+}
+
+variable "db_password_ssm_arn" {
+  type = string
+}
+
+variable "logit_hostname_ssm_arn" {
+  type = string
+}
+
+variable "logit_remote_port_ssm_arn" {
+  type = string
+}
+
+variable "new_relic_license_key_ssm_arn" {
+  type = string
+}
+
+variable "rollbar_access_token_ssm_arn" {
+  type = string
+}
+
+variable "cnet_ftp_password_ssm_arn" {
+  type = string
+}
+
+variable "sidekiq_username_ssm_arn" {
+  type = string
+}
+
+variable "sidekiq_password_ssm_arn" {
+  type = string
+}
+
+variable "secret_key_base_ssm_arn" {
+  type = string
+}
+
+variable "sendgrid_username_ssm_arn" {
+  type = string
+}
+
+variable "sendgrid_password_ssm_arn" {
+  type = string
+}
+
+variable "sendgrid_api_key_ssm_arn" {
   type = string
 }
 


### PR DESCRIPTION
This PR does a number of things:

1) Removes the use of the S3 bucket and client.env/spree.env files. The bucket and files are left in place for now for reference - to be deleted under a follow up ticket (SINF-371)

2) Removes any system parameters that can be inferred or set to sensible, overridable defaults (there are now just simple Terraform variables). Again - deletion of the orphaned system parameters to be done under SINF-371.

3) Converts any sensitive variables into ECS 'secrets' - which means they are not visible in the ECS console

4) Updated README 

