### PR TITLE
Feature/sinf 372 spree iam user

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ Check the README file for details of how to create the database.
 
 ### Pre install steps
 
-1. Create IAM user called `spree-user` with policy (`app-policy`) allowing full access to S3 (TODO: scripting of this added under SINF-372)
+1. Create an key pair instance called `{env}-spree-key'`
 
-2. Create an key pair instance called `{env}-spree-key'`
-
-3. Create SSM Params
+2. Create SSM Params
 
 | System Parameter                        | Description |
 | ----------------------------------------|-------------|
@@ -32,8 +30,6 @@ Check the README file for details of how to create the database.
 | /bat/{env}-logit-remote-port            | port to send logs to logit.io |
 | /bat/{env}-suppliers-sftp-bucket        | S3 bucket which holds suppliers sftp buckets |
 | /bat/{env}-sendgrid-api-key             | api key to sendgrid |
-| /bat/{env}-aws-access-key-id            | spree-user access key id |
-| /bat/{env}-aws-secret-access-key        | spree-user secret access key |
 | /bat/{env}-logit-node                   | url to logit.io elasticsearch cluster |
 | /bat/{env}-browser-rollbar-access-token | client side rollbar token |
 | /bat/{env}-cnet-ftp-username            | username to cnet ftp site |
@@ -45,7 +41,7 @@ Check the README file for details of how to create the database.
 | /bat/{env}-new-relic-license-key        | key from new relic site |
 
 
-4. Run `terraform apply`
+3. Run `terraform apply`
  - This will provision the BaT service components
 
 ### Post install steps

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -437,12 +437,9 @@ module "s3" {
 }
 
 module "iam" {
-  source                       = "../../iam"
-  environment                  = var.environment
-  s3_static_bucket_arn         = module.s3.s3_static_bucket_arn
-  s3_feed_bucket_arn           = module.s3.s3_feed_bucket_arn
-  s3_cnet_bucket_arn           = module.s3.s3_cnet_bucket_arn
-  s3_product_import_bucket_arn = module.s3.s3_product_import_bucket_arn
+  source                   = "../../iam"
+  environment              = var.environment
+  spree_bucket_access_arns = [module.s3.s3_static_bucket_arn, module.s3.s3_feed_bucket_arn, module.s3.s3_cnet_bucket_arn, module.s3.s3_product_import_bucket_arn]
 }
 
 module "memcached" {

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -115,13 +115,6 @@ data "aws_ssm_parameter" "sendgrid_api_key" {
   name = "/bat/${lower(var.environment)}-sendgrid-api-key"
 }
 
-data "aws_ssm_parameter" "aws_access_key_id" {
-  name = "/bat/${lower(var.environment)}-aws-access-key-id"
-}
-data "aws_ssm_parameter" "aws_secret_access_key" {
-  name = "/bat/${lower(var.environment)}-aws-secret-access-key"
-}
-
 data "aws_ssm_parameter" "browser_rollbar_access_token" {
   name = "/bat/${lower(var.environment)}-browser-rollbar-access-token"
 }
@@ -443,6 +436,15 @@ module "s3" {
   environment = var.environment
 }
 
+module "iam" {
+  source                       = "../../iam"
+  environment                  = var.environment
+  s3_static_bucket_arn         = module.s3.s3_static_bucket_arn
+  s3_feed_bucket_arn           = module.s3.s3_feed_bucket_arn
+  s3_cnet_bucket_arn           = module.s3.s3_cnet_bucket_arn
+  s3_product_import_bucket_arn = module.s3.s3_product_import_bucket_arn
+}
+
 module "memcached" {
   source                       = "../../memcached"
   aws_account_id               = var.aws_account_id
@@ -566,8 +568,8 @@ module "spree" {
   ecs_log_retention_in_days                          = var.ecs_log_retention_in_days
 
   # Secrets
-  aws_access_key_id_ssm_arn     = data.aws_ssm_parameter.aws_access_key_id.arn
-  aws_secret_access_key_ssm_arn = data.aws_ssm_parameter.aws_secret_access_key.arn
+  aws_access_key_id_ssm_arn     = module.iam.aws_access_key_id_ssm_arn
+  aws_secret_access_key_ssm_arn = module.iam.aws_secret_access_key_ssm_arn
   basicauth_username_ssm_arn    = data.aws_ssm_parameter.basic_auth_username.arn
   basicauth_password_ssm_arn    = data.aws_ssm_parameter.basic_auth_password.arn
   cnet_ftp_username_ssm_arn     = data.aws_ssm_parameter.cnet_ftp_username.arn
@@ -644,8 +646,8 @@ module "sidekiq" {
   ecs_log_retention_in_days                          = var.ecs_log_retention_in_days
 
   # Secrets
-  aws_access_key_id_ssm_arn     = data.aws_ssm_parameter.aws_access_key_id.arn
-  aws_secret_access_key_ssm_arn = data.aws_ssm_parameter.aws_secret_access_key.arn
+  aws_access_key_id_ssm_arn     = module.iam.aws_access_key_id_ssm_arn
+  aws_secret_access_key_ssm_arn = module.iam.aws_secret_access_key_ssm_arn
   basicauth_username_ssm_arn    = data.aws_ssm_parameter.basic_auth_username.arn
   basicauth_password_ssm_arn    = data.aws_ssm_parameter.basic_auth_password.arn
   cnet_ftp_username_ssm_arn     = data.aws_ssm_parameter.cnet_ftp_username.arn
@@ -729,8 +731,8 @@ module "s3_virus_scan" {
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   security_groups                    = [aws_security_group.s3-virus-scan.id]
-  aws_access_key_id                  = data.aws_ssm_parameter.aws_access_key_id.arn
-  aws_secret_access_key              = data.aws_ssm_parameter.aws_secret_access_key.arn
+  aws_access_key_id                  = module.iam.aws_access_key_id_ssm_arn
+  aws_secret_access_key              = module.iam.aws_secret_access_key_ssm_arn
   host                               = "http://${data.aws_ssm_parameter.lb_private_dns.value}:4567"
   stage                              = var.stage
   cidr_blocks                        = [data.aws_vpc.scale.cidr_block]

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,0 +1,73 @@
+##########################################################
+# IAM
+#
+# Spree application user
+##########################################################
+resource "aws_iam_user" "spree" {
+  name          = "spree-app-user"
+  force_destroy = true # ensures any non TF access keys are removed automatically
+}
+
+resource "aws_iam_access_key" "spree" {
+  user = aws_iam_user.spree.name
+}
+
+data "aws_ssm_parameter" "kms_id_ssm" {
+  name = "${lower(var.environment)}-ssm-encryption-key"
+}
+
+# Create System Parameters as we need these to inject as secrets into ECS
+resource "aws_ssm_parameter" "aws_access_key_id" {
+  name      = "/bat/${lower(var.environment)}-aws-access-key-id"
+  type      = "SecureString"
+  value     = aws_iam_access_key.spree.id
+  overwrite = true
+  key_id    = data.aws_ssm_parameter.kms_id_ssm.value
+}
+
+resource "aws_ssm_parameter" "aws_secret_access_key" {
+  name      = "/bat/${lower(var.environment)}-aws-secret-access-key"
+  type      = "SecureString"
+  value     = aws_iam_access_key.spree.secret
+  overwrite = true
+  key_id    = data.aws_ssm_parameter.kms_id_ssm.value
+}
+
+resource "aws_iam_user_policy" "spree" {
+  name = "spree-user-policy"
+  user = aws_iam_user.spree.name
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:GetObject",
+          "s3:GetObjectAcl",
+          "s3:DeleteObject"
+        ]
+        Effect = "Allow"
+        Resource = [
+          "${var.s3_static_bucket_arn}/*",
+          "${var.s3_feed_bucket_arn}/*",
+          "${var.s3_cnet_bucket_arn}/*",
+          "${var.s3_product_import_bucket_arn}/*"
+        ]
+      },
+      {
+        Action : ["s3:ListBucket"],
+        Effect : "Allow",
+        Resource : [
+          var.s3_static_bucket_arn,
+          var.s3_feed_bucket_arn,
+          var.s3_cnet_bucket_arn,
+          var.s3_product_import_bucket_arn,
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -51,22 +51,12 @@ resource "aws_iam_user_policy" "spree" {
           "s3:DeleteObject"
         ]
         Effect = "Allow"
-        Resource = [
-          "${var.s3_static_bucket_arn}/*",
-          "${var.s3_feed_bucket_arn}/*",
-          "${var.s3_cnet_bucket_arn}/*",
-          "${var.s3_product_import_bucket_arn}/*"
-        ]
+        Resource = formatlist("%s/*", var.spree_bucket_access_arns)
       },
       {
         Action : ["s3:ListBucket"],
         Effect : "Allow",
-        Resource : [
-          var.s3_static_bucket_arn,
-          var.s3_feed_bucket_arn,
-          var.s3_cnet_bucket_arn,
-          var.s3_product_import_bucket_arn,
-        ]
+        Resource : var.spree_bucket_access_arns
       }
     ]
   })

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_access_key_id_ssm_arn" {
+  value = aws_ssm_parameter.aws_access_key_id.arn
+}
+
+output "aws_secret_access_key_ssm_arn" {
+  value = aws_ssm_parameter.aws_secret_access_key.arn
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,19 @@
+variable "environment" {
+  type = string
+}
+
+variable "s3_static_bucket_arn" {
+  type = string
+}
+
+variable "s3_feed_bucket_arn" {
+  type = string
+}
+
+variable "s3_cnet_bucket_arn" {
+  type = string
+}
+
+variable "s3_product_import_bucket_arn" {
+  type = string
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -2,18 +2,6 @@ variable "environment" {
   type = string
 }
 
-variable "s3_static_bucket_arn" {
-  type = string
-}
-
-variable "s3_feed_bucket_arn" {
-  type = string
-}
-
-variable "s3_cnet_bucket_arn" {
-  type = string
-}
-
-variable "s3_product_import_bucket_arn" {
-  type = string
+variable "spree_bucket_access_arns" {
+  type = list(string)
 }

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -13,3 +13,19 @@ output "s3_product_import_name" {
 output "s3_cnet_import_bucket_name" {
   value = aws_s3_bucket.cnet.id
 }
+
+output "s3_static_bucket_arn" {
+  value = aws_s3_bucket.static.arn
+}
+
+output "s3_product_import_bucket_arn" {
+  value = aws_s3_bucket.product-import.arn
+}
+
+output "s3_cnet_bucket_arn" {
+  value = aws_s3_bucket.cnet.arn
+}
+
+output "s3_feed_bucket_arn" {
+  value = aws_s3_bucket.feed.arn
+}


### PR DESCRIPTION
This update will remove the need to manually create the `spree-user`, set permissions and access key system parameters during install.

The reasons for doing this are:
1. Tighten security on that user
2. Make it more consistently reproducible
3. Remove manual steps (and therefore make OAT/handover easier)

The Terraform has been updated to create a new IAM user `spree-app-user` (new name so it can exist alongside the old one for now). It will add a policy to grant access to the spree S3 buckets only (I assume this will sufficient - it had full access on all S3 buckets previously), create an access key and associated system parameters and inject those into the ECS tasks.

I have also added some documentation to show how to rotate the access key in future if/when needed (to ensure it stays under Terraform control - thanks to @tommyb82 for the steer).

https://crowncommercialservice.atlassian.net/wiki/spaces/SCALE/pages/2422439947/Rotate+spree-app-user+IAM+access+key
