### PR TITLE
SINF-391 - enabled dynamic log retention periods

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -50,4 +50,6 @@ module "deploy" {
   s3_virus_scan_memory            = 4096
   s3_virus_scan_ec2_instance_type = "t2.large"
   dev_user_public_key             = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJgtBY5vWuL/S7zVpxibQfIS57Uxa86TVX3f7aCYV1j8XIYZjCpwGpmDTHsRonCY1uyZ03jDvNFYXJjwwvwkztDtofvUWsrJ+L5UXSs+jii4+tpV5g5y+Tqp3KzdJxcD8Y4PQqqi6iYfNYs27FRgYxffocnQJLzG/naoQiMPBZ+ckqABfQCTLJg5175HvkCAzZ3oBQ9NEo31Qhc9SNb4PnjaI8FjRuCRN9tFtijp2ZRnExI41abWfVw6/bfQmTeQcgj4HMvJeQ4MOJ3jd4Vy6PhpSxXvOkY6kcI/5b/FeFDbGxJ7Ds1UvInIqEKi+x/i8ajkls0FEgLt1FCrnV8wbR"
+  api_gw_log_retention_in_days    = 30
+  ecs_log_retention_in_days       = 30
 }

--- a/terraform/environments/sbx1/main.tf
+++ b/terraform/environments/sbx1/main.tf
@@ -27,18 +27,20 @@ data "aws_ssm_parameter" "aws_account_id" {
 }
 
 module "deploy" {
-  source                    = "../../modules/configs/deploy-all"
-  aws_account_id            = data.aws_ssm_parameter.aws_account_id.value
-  environment               = local.environment
-  rollbar_env               = local.environment
-  client_cpu                = 2048
-  client_memory             = 7168 #8192
-  client_ec2_instance_type  = "t2.large"
-  spree_cpu                 = 2048
-  spree_memory              = 7168 #8192
-  spree_ec2_instance_type   = "t2.large"
-  sidekiq_cpu               = 2048
-  sidekiq_memory            = 7168 #8192
-  sidekiq_ec2_instance_type = "t2.large"
-  dev_user_public_key       = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaHta2G06kHC/9d0g2mE+y5K9LTb/FAwqeu/LqRk5E4Ebd6dzEpo0+arONcu/kFbfSRxTUQZ+h4HcbsfLz50r5R1LN6fnjXh74gluElUdc8Fye7Y8DvYnru0Clk9WA1w2CI9ARbsH15pymV9HeY7D/I/1AXc5P8ESFyMTbxgxnoAZ/FGDGIr9P0ahGMb/qpCyxCoTv6TliQ2dCrhEjwKLPaf5C73ptyZJrh9HXpB6utnu/fa0T/QFfN6dvhjuLdgj701epWBfMRChXgZeuWRDGyxIj6YTBw8PlRiPuHuP1xU4pJLYjcvSBY4ol3ySMuHqpVK/3F/BZ0Y6rhhnEy42Z"
+  source                       = "../../modules/configs/deploy-all"
+  aws_account_id               = data.aws_ssm_parameter.aws_account_id.value
+  environment                  = local.environment
+  rollbar_env                  = local.environment
+  client_cpu                   = 2048
+  client_memory                = 7168 #8192
+  client_ec2_instance_type     = "t2.large"
+  spree_cpu                    = 2048
+  spree_memory                 = 7168 #8192
+  spree_ec2_instance_type      = "t2.large"
+  sidekiq_cpu                  = 2048
+  sidekiq_memory               = 7168 #8192
+  sidekiq_ec2_instance_type    = "t2.large"
+  dev_user_public_key          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaHta2G06kHC/9d0g2mE+y5K9LTb/FAwqeu/LqRk5E4Ebd6dzEpo0+arONcu/kFbfSRxTUQZ+h4HcbsfLz50r5R1LN6fnjXh74gluElUdc8Fye7Y8DvYnru0Clk9WA1w2CI9ARbsH15pymV9HeY7D/I/1AXc5P8ESFyMTbxgxnoAZ/FGDGIr9P0ahGMb/qpCyxCoTv6TliQ2dCrhEjwKLPaf5C73ptyZJrh9HXpB6utnu/fa0T/QFfN6dvhjuLdgj701epWBfMRChXgZeuWRDGyxIj6YTBw8PlRiPuHuP1xU4pJLYjcvSBY4ol3ySMuHqpVK/3F/BZ0Y6rhhnEy42Z"
+  api_gw_log_retention_in_days = 14
+  ecs_log_retention_in_days    = 14
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -563,6 +563,8 @@ module "spree" {
   sidekiq_concurrency_cnet_import_missing_xmls       = var.sidekiq_concurrency_cnet_import_missing_xmls
   rack_timeout_service_timeout                       = var.rack_timeout_service_timeout
   enable_admin_panel_orders                          = var.enable_admin_panel_orders
+  ecs_log_retention_in_days                          = var.ecs_log_retention_in_days
+
   # Secrets
   aws_access_key_id_ssm_arn     = data.aws_ssm_parameter.aws_access_key_id.arn
   aws_secret_access_key_ssm_arn = data.aws_ssm_parameter.aws_secret_access_key.arn
@@ -639,6 +641,8 @@ module "sidekiq" {
   sidekiq_concurrency_cnet_import_missing_xmls       = var.sidekiq_concurrency_cnet_import_missing_xmls
   rack_timeout_service_timeout                       = var.rack_timeout_service_timeout
   enable_admin_panel_orders                          = var.enable_admin_panel_orders
+  ecs_log_retention_in_days                          = var.ecs_log_retention_in_days
+
   # Secrets
   aws_access_key_id_ssm_arn     = data.aws_ssm_parameter.aws_access_key_id.arn
   aws_secret_access_key_ssm_arn = data.aws_ssm_parameter.aws_secret_access_key.arn
@@ -693,6 +697,7 @@ module "client" {
   enable_ordering                      = var.enable_ordering
   logit_application                    = var.logit_application == null ? "BAT-Buyer-UI-${upper(var.environment)}" : var.logit_application
   error_pages_unknonwn_server_endpoint = var.error_pages_unknonwn_server_endpoint
+  ecs_log_retention_in_days            = var.ecs_log_retention_in_days
   # Secrets
   browser_rollbar_access_token_ssm_arn = data.aws_ssm_parameter.browser_rollbar_access_token.arn
   rollbar_access_token_ssm_arn         = data.aws_ssm_parameter.rollbar_access_token.arn
@@ -729,6 +734,7 @@ module "s3_virus_scan" {
   host                               = "http://${data.aws_ssm_parameter.lb_private_dns.value}:4567"
   stage                              = var.stage
   cidr_blocks                        = [data.aws_vpc.scale.cidr_block]
+  ecs_log_retention_in_days          = var.ecs_log_retention_in_days
 }
 
 ######################################

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -31,7 +31,7 @@ resource "aws_api_gateway_stage" "bat" {
     aws_cloudwatch_log_group.api_gw_execution
   ]
 
-  stage_name    = "${lower(var.environment)}"
+  stage_name    = lower(var.environment)
   rest_api_id   = var.scale_rest_api_id
   deployment_id = aws_api_gateway_deployment.bat.id
 }

--- a/terraform/modules/services/api-deployment/main.tf
+++ b/terraform/modules/services/api-deployment/main.tf
@@ -31,7 +31,7 @@ resource "aws_api_gateway_stage" "bat" {
     aws_cloudwatch_log_group.api_gw_execution
   ]
 
-  stage_name    = lower(var.environment)
+  stage_name    = "${lower(var.environment)}"
   rest_api_id   = var.scale_rest_api_id
   deployment_id = aws_api_gateway_deployment.bat.id
 }
@@ -48,7 +48,7 @@ resource "aws_api_gateway_method_settings" "scale" {
 }
 
 resource "aws_cloudwatch_log_group" "api_gw_execution" {
-  name              = "API-Gateway-Execution-Logs_${var.scale_rest_api_id}/${lower(var.environment)}-bat"
+  name              = "API-Gateway-Execution-Logs_${var.scale_rest_api_id}/${lower(var.environment)}"
   retention_in_days = var.api_gw_log_retention_in_days
 }
 

--- a/terraform/modules/services/client/ecs.tf
+++ b/terraform/modules/services/client/ecs.tf
@@ -144,5 +144,5 @@ resource "aws_ecs_service" "client" {
 
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/service/scale/bat-buyer-ui"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }

--- a/terraform/modules/services/client/variables.tf
+++ b/terraform/modules/services/client/variables.tf
@@ -107,6 +107,10 @@ variable "enable_ordering" {
   type = string
 }
 
+variable "ecs_log_retention_in_days" {
+  type    = number
+}
+
 #########
 # Secrets
 #########

--- a/terraform/modules/services/s3-virus-scan/ecs.tf
+++ b/terraform/modules/services/s3-virus-scan/ecs.tf
@@ -76,7 +76,7 @@ resource "aws_ecs_service" "s3_virus_scan" {
 
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/service/scale/s3_virus_scan"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }
 
 

--- a/terraform/modules/services/s3-virus-scan/variables.tf
+++ b/terraform/modules/services/s3-virus-scan/variables.tf
@@ -73,3 +73,7 @@ variable "stage" {
 variable "cidr_blocks" {
   type = list(string)
 }
+
+variable "ecs_log_retention_in_days" {
+  type    = number
+}

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -104,5 +104,5 @@ resource "aws_ecs_service" "sidekiq" {
 
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/service/scale/spree-sidekiq"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }

--- a/terraform/modules/services/sidekiq/variables.tf
+++ b/terraform/modules/services/sidekiq/variables.tf
@@ -142,6 +142,10 @@ variable "enable_admin_panel_orders" {
   type = string
 }
 
+variable "ecs_log_retention_in_days" {
+  type = number
+}
+
 #########
 # Secrets
 #########

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -211,5 +211,5 @@ resource "aws_ecs_service" "spree" {
 
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/service/scale/spree"
-  retention_in_days = 7
+  retention_in_days = var.ecs_log_retention_in_days
 }

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -214,6 +214,10 @@ variable "enable_admin_panel_orders" {
   type = string
 }
 
+variable "ecs_log_retention_in_days" {
+  type = number
+}
+
 #########
 # Secrets
 #########


### PR DESCRIPTION
ECS log retention periods had been hardcoded to 7 days. Made dynamic and set NTF retention to 30 days to match FaT.

Also - API Gateway logging had this historical issue of creating 2 log groups - one of which was empty. This was due to a mismatch between the `aws_cloudwatch_log_group` resource name (which had the retention setting), and the log created by the API Gateway. So instead of changing the existing log retention period, it would create a new log that was never used. Aligned these now (should also be applied to FaT/Shared if ok - will create a tech debt JIRA for this)