### PR TITLE
Feature/sinf 394 encrypt and version s3

### DIFF
--- a/terraform/environments/sbx1/main.tf
+++ b/terraform/environments/sbx1/main.tf
@@ -27,20 +27,21 @@ data "aws_ssm_parameter" "aws_account_id" {
 }
 
 module "deploy" {
-  source                       = "../../modules/configs/deploy-all"
-  aws_account_id               = data.aws_ssm_parameter.aws_account_id.value
-  environment                  = local.environment
-  rollbar_env                  = local.environment
-  client_cpu                   = 2048
-  client_memory                = 7168 #8192
-  client_ec2_instance_type     = "t2.large"
-  spree_cpu                    = 2048
-  spree_memory                 = 7168 #8192
-  spree_ec2_instance_type      = "t2.large"
-  sidekiq_cpu                  = 2048
-  sidekiq_memory               = 7168 #8192
-  sidekiq_ec2_instance_type    = "t2.large"
-  dev_user_public_key          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaHta2G06kHC/9d0g2mE+y5K9LTb/FAwqeu/LqRk5E4Ebd6dzEpo0+arONcu/kFbfSRxTUQZ+h4HcbsfLz50r5R1LN6fnjXh74gluElUdc8Fye7Y8DvYnru0Clk9WA1w2CI9ARbsH15pymV9HeY7D/I/1AXc5P8ESFyMTbxgxnoAZ/FGDGIr9P0ahGMb/qpCyxCoTv6TliQ2dCrhEjwKLPaf5C73ptyZJrh9HXpB6utnu/fa0T/QFfN6dvhjuLdgj701epWBfMRChXgZeuWRDGyxIj6YTBw8PlRiPuHuP1xU4pJLYjcvSBY4ol3ySMuHqpVK/3F/BZ0Y6rhhnEy42Z"
-  api_gw_log_retention_in_days = 14
-  ecs_log_retention_in_days    = 14
+  source                          = "../../modules/configs/deploy-all"
+  aws_account_id                  = data.aws_ssm_parameter.aws_account_id.value
+  environment                     = local.environment
+  rollbar_env                     = local.environment
+  client_cpu                      = 2048
+  client_memory                   = 7168 #8192
+  client_ec2_instance_type        = "t2.large"
+  spree_cpu                       = 2048
+  spree_memory                    = 7168 #8192
+  spree_ec2_instance_type         = "t2.large"
+  sidekiq_cpu                     = 2048
+  sidekiq_memory                  = 7168 #8192
+  sidekiq_ec2_instance_type       = "t2.large"
+  dev_user_public_key             = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaHta2G06kHC/9d0g2mE+y5K9LTb/FAwqeu/LqRk5E4Ebd6dzEpo0+arONcu/kFbfSRxTUQZ+h4HcbsfLz50r5R1LN6fnjXh74gluElUdc8Fye7Y8DvYnru0Clk9WA1w2CI9ARbsH15pymV9HeY7D/I/1AXc5P8ESFyMTbxgxnoAZ/FGDGIr9P0ahGMb/qpCyxCoTv6TliQ2dCrhEjwKLPaf5C73ptyZJrh9HXpB6utnu/fa0T/QFfN6dvhjuLdgj701epWBfMRChXgZeuWRDGyxIj6YTBw8PlRiPuHuP1xU4pJLYjcvSBY4ol3ySMuHqpVK/3F/BZ0Y6rhhnEy42Z"
+  api_gw_log_retention_in_days    = 14
+  ecs_log_retention_in_days       = 14
+  s3_noncurrent_retention_in_days = 1
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -436,11 +436,12 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_kms_decrypt_s
 # Modules
 ######################################
 
-
 module "s3" {
-  source      = "../../s3"
-  stage       = var.stage
-  environment = var.environment
+  source                          = "../../s3"
+  stage                           = var.stage
+  environment                     = var.environment
+  s3_noncurrent_retention_in_days = var.s3_noncurrent_retention_in_days
+  s3_force_destroy                = var.s3_force_destroy
 }
 
 module "memcached" {
@@ -529,7 +530,6 @@ module "spree" {
   redis_url                                          = module.memcached.redis_url
   memcached_endpoint                                 = module.memcached.memcached_endpoint
   security_groups                                    = [aws_security_group.spree.id]
-  env_file                                           = module.s3.env_file_spree
   cloudfront_id                                      = data.aws_ssm_parameter.bat_backend_cloudfront_id.value
   ecr_image_id_spree                                 = var.ecr_image_id_spree
   elasticsearch_url                                  = "https://${data.aws_ssm_parameter.elasticsearch_url.value}:443"
@@ -608,7 +608,6 @@ module "sidekiq" {
   rollbar_env                                        = var.rollbar_env
   redis_url                                          = module.memcached.redis_url
   security_groups                                    = [aws_security_group.spree.id]
-  env_file                                           = module.s3.env_file_spree
   ecr_image_id_spree                                 = var.ecr_image_id_spree
   elasticsearch_url                                  = "https://${data.aws_ssm_parameter.elasticsearch_url.value}:443"
   buyer_ui_url                                       = "https://${data.aws_ssm_parameter.hosted_zone_name_cdn_bat_client.value}"

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -20,6 +20,17 @@ variable "basic_auth_enabled" {
   default = true
 }
 
+variable "s3_noncurrent_retention_in_days" {
+  type    = number
+  default = 14
+}
+
+variable "s3_force_destroy" {
+  type    = bool
+  default = true
+}
+
+
 #######################
 # SPREE CLIENT
 #######################

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -10,47 +10,81 @@ module "globals" {
 
 resource "aws_s3_bucket" "static" {
   bucket        = "spree-${lower(var.environment)}-${lower(var.stage)}"
-  force_destroy = true
+  force_destroy = var.s3_force_destroy
 
-  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
-}
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
-# Deprecated (as of SINF-356) - this bucket is no longer needed.
-# Leaving for now, as these buckets contain .env files which have info that
-# may be needed for a short while after transition to system param approach.
-# To be removed as part of follow up task SINF-371
-resource "aws_s3_bucket" "system" {
-  bucket        = "system-spree-${lower(var.environment)}-${lower(var.stage)}"
-  force_destroy = true
+  versioning {
+    enabled = true
+  }
 
-  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
-}
-
-resource "aws_s3_bucket" "feed" {
-  bucket        = "feed-spree-${lower(var.environment)}-${lower(var.stage)}"
-  force_destroy = true
+  lifecycle_rule {
+    id      = "expire-noncurrent-after-${var.s3_noncurrent_retention_in_days}-days"
+    enabled = true
+    noncurrent_version_expiration {
+      days = var.s3_noncurrent_retention_in_days
+    }
+  }
 
   tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket" "cnet" {
   bucket        = "cnet-spree-${lower(var.environment)}-${lower(var.stage)}"
-  force_destroy = true
+  force_destroy = var.s3_force_destroy
 
-  tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
-}
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
-resource "aws_s3_bucket_object" "env-spree" {
-  bucket = aws_s3_bucket.system.id
-  key    = "spree.env"
-  acl    = "private"
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "expire-noncurrent-after-${var.s3_noncurrent_retention_in_days}-days"
+    enabled = true
+    noncurrent_version_expiration {
+      days = var.s3_noncurrent_retention_in_days
+    }
+  }
 
   tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }
 
 resource "aws_s3_bucket" "product-import" {
   bucket        = "spree-${lower(var.environment)}-products-import"
-  force_destroy = true
+  force_destroy = var.s3_force_destroy
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "expire-noncurrent-after-${var.s3_noncurrent_retention_in_days}-days"
+    enabled = true
+    noncurrent_version_expiration {
+      days = var.s3_noncurrent_retention_in_days
+    }
+  }
 
   tags = merge(module.globals.project_resource_tags, { AppType = "S3" })
 }

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,7 +1,3 @@
-output "env_file_spree" {
-  value = "${aws_s3_bucket.system.arn}/${aws_s3_bucket_object.env-spree.id}"
-}
-
 output "s3_static_bucket_name" {
   value = aws_s3_bucket.static.id
 }

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -5,3 +5,11 @@ variable "stage" {
 variable "environment" {
   type = string
 }
+
+variable "s3_noncurrent_retention_in_days" {
+  type = number
+}
+
+variable "s3_force_destroy" {
+  type = bool
+}

--- a/terraform/modules/services/sidekiq/ecs.tf
+++ b/terraform/modules/services/sidekiq/ecs.tf
@@ -19,7 +19,6 @@ data "template_file" "app_sidekiq" {
     basicauth_enabled                                  = var.basicauth_enabled
     products_import_bucket                             = var.products_import_bucket
     rollbar_env                                        = var.rollbar_env
-    env_file                                           = var.env_file
     redis_url                                          = var.redis_url
     elasticsearch_url                                  = var.elasticsearch_url
     buyer_ui_url                                       = var.buyer_ui_url

--- a/terraform/modules/services/sidekiq/variables.tf
+++ b/terraform/modules/services/sidekiq/variables.tf
@@ -54,10 +54,6 @@ variable "rollbar_env" {
   type = string
 }
 
-variable "env_file" {
-  type = string
-}
-
 variable "redis_url" {
   type = string
 }

--- a/terraform/modules/services/spree/ecs.tf
+++ b/terraform/modules/services/spree/ecs.tf
@@ -113,7 +113,6 @@ data "template_file" "app_client" {
     basicauth_enabled                                  = var.basicauth_enabled
     products_import_bucket                             = var.products_import_bucket
     rollbar_env                                        = var.rollbar_env
-    env_file                                           = var.env_file
     redis_url                                          = var.redis_url
     memcached_endpoint                                 = var.memcached_endpoint
     elasticsearch_url                                  = var.elasticsearch_url

--- a/terraform/modules/services/spree/variables.tf
+++ b/terraform/modules/services/spree/variables.tf
@@ -62,10 +62,6 @@ variable "rollbar_env" {
   type = string
 }
 
-variable "env_file" {
-  type = string
-}
-
 variable "redis_url" {
   type = string
 }


### PR DESCRIPTION
This PR encrypts data in S3 and also enables versioning (and removal of old versions after 14 days) - based on Som's responses on ticker SINF-394.

I've also rolled up SINF-379 into this ticket - which was to remove the (now obsolete) bucket which contained `spree.env` and `client.env` as part of the tidy up, along with the `feed` S3 bucket which Tony has confirmed is no longer needed.

I've also added a 'force destroy' flag, defaulting to true. This was hard coded before - but thought we may want to set this to `true` on prod to ensure the bucket cannot be accidentally deleted.

The only part I want to verify is the S3 lifecycle rule - want to be sure that it doesn't remove current objects, only old versions. I set the period to 1 day on SBX1 to test this - which I should be able to confirm later today.