### PR TITLE
Feature/sinf 394 400 temp remove encryption

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -440,7 +440,7 @@ module "s3" {
 module "iam" {
   source                   = "../../iam"
   environment              = var.environment
-  spree_bucket_access_arns = [module.s3.s3_static_bucket_arn, module.s3.s3_cnet_bucket_arn, module.s3.s3_product_import_bucket_arn]
+  spree_bucket_access_arns = [module.s3.s3_static_bucket_arn, module.s3.s3_cnet_bucket_arn, module.s3.s3_product_import_bucket_arn, "arn:aws:s3:::${local.suppliers_sftp_bucket}"]
 }
 
 module "memcached" {

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -45,8 +45,8 @@ resource "aws_elasticache_replication_group" "redis" {
   security_group_ids            = var.security_group_redis_ids
   subnet_group_name             = aws_elasticache_subnet_group.ec.name
 
-  at_rest_encryption_enabled    = true
-  transit_encryption_enabled    = true
+  #at_rest_encryption_enabled    = true
+  #transit_encryption_enabled    = true
 
   # Without this it complains if you re'apply' with no changes
   lifecycle {

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -45,6 +45,7 @@ resource "aws_elasticache_replication_group" "redis" {
   security_group_ids            = var.security_group_redis_ids
   subnet_group_name             = aws_elasticache_subnet_group.ec.name
 
+  # Requires change to Spree code to work - reapply as part of SINF-403
   #at_rest_encryption_enabled    = true
   #transit_encryption_enabled    = true
 

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -12,13 +12,13 @@ resource "aws_s3_bucket" "static" {
   bucket        = "spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = var.s3_force_destroy
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  #server_side_encryption_configuration {
+  #  rule {
+  #    apply_server_side_encryption_by_default {
+  #      sse_algorithm = "AES256"
+  #    }
+  #  }
+  #}
 
   versioning {
     enabled = true
@@ -39,13 +39,13 @@ resource "aws_s3_bucket" "cnet" {
   bucket        = "cnet-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = var.s3_force_destroy
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  #server_side_encryption_configuration {
+  #  rule {
+  #    apply_server_side_encryption_by_default {
+  #      sse_algorithm = "AES256"
+  #    }
+  #  }
+  #}
 
   versioning {
     enabled = true
@@ -66,13 +66,13 @@ resource "aws_s3_bucket" "product-import" {
   bucket        = "spree-${lower(var.environment)}-products-import"
   force_destroy = var.s3_force_destroy
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  #server_side_encryption_configuration {
+  #  rule {
+  #    apply_server_side_encryption_by_default {
+  #      sse_algorithm = "AES256"
+  #    }
+  #  }
+  #}
 
   versioning {
     enabled = true

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -12,6 +12,7 @@ resource "aws_s3_bucket" "static" {
   bucket        = "spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = var.s3_force_destroy
 
+  # Requires change to Spree code to work - reapply as part of SINF-402
   #server_side_encryption_configuration {
   #  rule {
   #    apply_server_side_encryption_by_default {
@@ -39,6 +40,7 @@ resource "aws_s3_bucket" "cnet" {
   bucket        = "cnet-spree-${lower(var.environment)}-${lower(var.stage)}"
   force_destroy = var.s3_force_destroy
 
+  # Requires change to Spree code to work - reapply as part of SINF-402
   #server_side_encryption_configuration {
   #  rule {
   #    apply_server_side_encryption_by_default {
@@ -66,6 +68,7 @@ resource "aws_s3_bucket" "product-import" {
   bucket        = "spree-${lower(var.environment)}-products-import"
   force_destroy = var.s3_force_destroy
 
+  # Requires change to Spree code to work - reapply as part of SINF-402
   #server_side_encryption_configuration {
   #  rule {
   #    apply_server_side_encryption_by_default {


### PR DESCRIPTION
Temporarily removed encryption for S3 and Redis until suitable changes are made to Spree code to support them (covered in SINF-402 and SINF-403). This code currently deployed on SBX1.