### PR TITLE
SCA-2430 Set rack timeout to 60 seconds for all envs

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -46,7 +46,6 @@ module "deploy" {
   redis_node_type                      = "cache.t3.medium"
   error_pages_unknonwn_server_endpoint = true
   email_from                           = "bt@sprks.eu"
-  rack_timeout_service_timeout         = 60 #seconds timeout
   enable_ordering                      = true
   enable_admin_panel_orders            = true
 

--- a/terraform/environments/int/main.tf
+++ b/terraform/environments/int/main.tf
@@ -50,6 +50,5 @@ module "deploy" {
   s3_virus_scan_ec2_instance_type = "t2.large"
   basic_auth_enabled              = false
   new_relic_app_name              = "Bat Spree SiT"
-  rack_timeout_service_timeout    = 60 #seconds timeout
   dev_user_public_key             = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD8Halwg1FWTsqO30Xci6UBLvHNvaKqv2tThr6XH5phO9gDFdmqJ2475Bk4WGBbtE6lWv1967F2GzskLk1AVXzGJNK7rJotLn3UXiMMDHHmRExY2gY/zLwc9Y5RXiZ92BrOgV5K+GYhLkFQgEPKGVxKWzIRbXyo6XZ4hZ7hQjQ8urhMwnWeNaz5wugBuAFqBwCq20bADlT70oi3e/f9EvAyQ8uLFFANLvpBYFiss5Kym0oNPJ+JVnfBjVqrvSCz74f2ryEufFjuGcefaTi2/KVZ/mHhUuvSLqadVyr6zSB9tJv6Lz4A1JAyugnr0KCgriPbY5VVUZKtiFF9Tw5CW+zr"
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -246,7 +246,7 @@ variable "sidekiq_concurrency_cnet_import_missing_xmls" {
 
 variable "rack_timeout_service_timeout" {
   type    = number
-  default = 15
+  default = 60
 }
 
 #######################


### PR DESCRIPTION
Fix the issue where the basket timed out, when it has more than 50 items