### PR TITLE
SINF-408 - added CW alarms for ECS services

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -813,3 +813,57 @@ module "api-deployment" {
   catalogue_api_gateway_integration = module.catalogue.catalogue_api_gateway_integration
   auth_api_gateway_integration      = module.auth.auth_api_gateway_integration
 }
+
+module "cloudwatch-alarms-spree" {
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs_spree.ecs_cluster_name
+  ecs_service_name        = module.spree.ecs_service_name
+  service_name            = "bat-spree"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
+}
+
+module "cloudwatch-alarms-sidekiq" {
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs_sidekiq.ecs_cluster_name
+  ecs_service_name        = module.sidekiq.ecs_service_name
+  service_name            = "bat-sidekiq"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
+}
+
+module "cloudwatch-alarms-client" {
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs_client.ecs_cluster_name
+  ecs_service_name        = module.client.ecs_service_name
+  service_name            = "bat-client"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
+}
+
+module "cloudwatch-alarms-virus-scan" {
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs_s3_virus_scan.ecs_cluster_name
+  ecs_service_name        = module.s3_virus_scan.ecs_service_name
+  service_name            = "bat-s3-virus-scan"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
+}
+
+module "cloudwatch-alarms-catalogue" {
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs_fargate.ecs_cluster_name
+  ecs_service_name        = module.catalogue.ecs_service_name
+  service_name            = "bat-catalogue"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
+}
+
+module "cloudwatch-alarms-auth" {
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  ecs_cluster_name        = module.ecs_fargate.ecs_cluster_name
+  ecs_service_name        = module.auth.ecs_service_name
+  service_name            = "bat-auth"
+  ecs_expected_task_count = length(split(",", data.aws_ssm_parameter.private_app_subnet_ids.value))
+}

--- a/terraform/modules/cw-alarms/main.tf
+++ b/terraform/modules/cw-alarms/main.tf
@@ -1,0 +1,66 @@
+#########################################################
+# Cloudwatch: Alarms
+#
+# Create performance alarms.
+#########################################################
+
+resource "aws_sns_topic" "alarms" {
+  name = "CCS-EU2-${upper(var.environment)}-CW-ALARMS-${upper(var.service_name)}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu" {
+  alarm_name                = "${lower(var.service_name)}-service-cpu-alarm"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/ECS"
+  period                    = "300"
+  statistic                 = "Average"
+  threshold                 = "80"
+  alarm_description         = "This metric monitors cpu utilization"
+  insufficient_data_actions = []
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory" {
+  alarm_name                = "${lower(var.service_name)}-service-memory-alarm"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "MemoryUtilization"
+  namespace                 = "AWS/ECS"
+  period                    = "300"
+  statistic                 = "Average"
+  threshold                 = "80"
+  alarm_description         = "This metric monitors cpu utilization"
+  insufficient_data_actions = []
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "task" {
+  alarm_name                = "${lower(var.service_name)}-service-task-alarm"
+  comparison_operator       = "LessThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "MemoryUtilization"
+  namespace                 = "AWS/ECS"
+  period                    = "60"
+  statistic                 = "SampleCount"
+  threshold                 = var.ecs_expected_task_count
+  alarm_description         = "This metric monitors task removals"
+  insufficient_data_actions = []
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+}

--- a/terraform/modules/cw-alarms/variables.tf
+++ b/terraform/modules/cw-alarms/variables.tf
@@ -1,0 +1,19 @@
+variable environment {
+  type = string
+}
+
+variable ecs_cluster_name {
+  type = string
+}
+
+variable ecs_service_name {
+  type = string
+}
+
+variable service_name {
+  type = string
+}
+
+variable "ecs_expected_task_count" {
+  type = string
+}

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -1,3 +1,7 @@
 output "ecs_cluster_id" {
   value = aws_ecs_cluster.main.id
 }
+
+output "ecs_cluster_name" {
+  value = aws_ecs_cluster.main.name
+}

--- a/terraform/modules/services/client/outputs.tf
+++ b/terraform/modules/services/client/outputs.tf
@@ -1,3 +1,3 @@
-//output "client_api_gateway_integration" {
-//  value = aws_api_gateway_integration.client_proxy.http_method
-//}
+output "ecs_service_name" {
+  value = aws_ecs_service.client.name
+}

--- a/terraform/modules/services/s3-virus-scan/outputs.tf
+++ b/terraform/modules/services/s3-virus-scan/outputs.tf
@@ -1,0 +1,3 @@
+output "ecs_service_name" {
+  value = aws_ecs_service.s3_virus_scan.name
+}

--- a/terraform/modules/services/sidekiq/outputs.tf
+++ b/terraform/modules/services/sidekiq/outputs.tf
@@ -1,0 +1,3 @@
+output "ecs_service_name" {
+  value = aws_ecs_service.sidekiq.name
+}

--- a/terraform/modules/services/spree/outputs.tf
+++ b/terraform/modules/services/spree/outputs.tf
@@ -1,0 +1,3 @@
+output "ecs_service_name" {
+  value = aws_ecs_service.spree.name
+}


### PR DESCRIPTION
Added CloudWatch alarms that publish to SNS topics if Memory or CPU utilization ^80% or if task count drops below expected (following conventions on FaT)