### PR TITLE
Add encryption for S3 and Redis

### DIFF
--- a/terraform/environments/sbx3/main.tf
+++ b/terraform/environments/sbx3/main.tf
@@ -40,6 +40,7 @@ module "deploy" {
   sidekiq_cpu               = 2048
   sidekiq_memory            = 7168 #8192
   sidekiq_ec2_instance_type = "t2.large"
+  ecr_image_id_spree        = "sbx3-latest"
 
   # Made these small for SBX environments (what should default be?)
   s3_virus_scan_cpu               = 1024

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -440,7 +440,8 @@ module "s3" {
 module "iam" {
   source                   = "../../iam"
   environment              = var.environment
-  spree_bucket_access_arns = [module.s3.s3_static_bucket_arn, module.s3.s3_cnet_bucket_arn, module.s3.s3_product_import_bucket_arn, "arn:aws:s3:::${local.suppliers_sftp_bucket}"]
+
+  spree_bucket_access_arns = [module.s3.s3_static_bucket_arn, module.s3.s3_cnet_bucket_arn, module.s3.s3_product_import_bucket_arn]
 }
 
 module "memcached" {

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -51,7 +51,13 @@ resource "aws_iam_user_policy" "spree" {
           "s3:DeleteObject",
           "s3:GetObjectTagging",
           "s3:PutObjectTagging",
-          "s3:DeleteObjectTagging"
+          "s3:DeleteObjectTagging",
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:ReEncryptTo",
+          "kms:DescribeKey",
+          "kms:ReEncryptFrom"
         ]
         Effect = "Allow"
         Resource = formatlist("%s/*", var.spree_bucket_access_arns)

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -51,13 +51,7 @@ resource "aws_iam_user_policy" "spree" {
           "s3:DeleteObject",
           "s3:GetObjectTagging",
           "s3:PutObjectTagging",
-          "s3:DeleteObjectTagging",
-          "kms:Decrypt",
-          "kms:Encrypt",
-          "kms:GenerateDataKey",
-          "kms:ReEncryptTo",
-          "kms:DescribeKey",
-          "kms:ReEncryptFrom"
+          "s3:DeleteObjectTagging"
         ]
         Effect = "Allow"
         Resource = formatlist("%s/*", var.spree_bucket_access_arns)

--- a/terraform/modules/memcached/main.tf
+++ b/terraform/modules/memcached/main.tf
@@ -46,8 +46,8 @@ resource "aws_elasticache_replication_group" "redis" {
   subnet_group_name             = aws_elasticache_subnet_group.ec.name
 
   # Requires change to Spree code to work - reapply as part of SINF-403
-  #at_rest_encryption_enabled    = true
-  #transit_encryption_enabled    = true
+  at_rest_encryption_enabled    = true
+  transit_encryption_enabled    = true
 
   # Without this it complains if you re'apply' with no changes
   lifecycle {
@@ -58,7 +58,7 @@ resource "aws_elasticache_replication_group" "redis" {
 }
 
 # MultiAZ is not 'enabled' by default on Redis (although docs say it should be if 'automatic_failover_enabled' is true)
-# Workaround is to run a command to set it after the resource has been creted 
+# Workaround is to run a command to set it after the resource has been creted
 # It may be this is not required in a later version of Terraform
 resource "null_resource" "nr" {
   triggers = {

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_url" {
-  value = "redis://${aws_elasticache_replication_group.redis.primary_endpoint_address}"
+  value = "rediss://${aws_elasticache_replication_group.redis.primary_endpoint_address}"
 }
 
 output "memcached_endpoint" {

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -13,13 +13,13 @@ resource "aws_s3_bucket" "static" {
   force_destroy = var.s3_force_destroy
 
   # Requires change to Spree code to work - reapply as part of SINF-402
-  #server_side_encryption_configuration {
-  #  rule {
-  #    apply_server_side_encryption_by_default {
-  #      sse_algorithm = "AES256"
-  #    }
-  #  }
-  #}
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
   versioning {
     enabled = true
@@ -41,13 +41,13 @@ resource "aws_s3_bucket" "cnet" {
   force_destroy = var.s3_force_destroy
 
   # Requires change to Spree code to work - reapply as part of SINF-402
-  #server_side_encryption_configuration {
-  #  rule {
-  #    apply_server_side_encryption_by_default {
-  #      sse_algorithm = "AES256"
-  #    }
-  #  }
-  #}
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
   versioning {
     enabled = true
@@ -69,13 +69,13 @@ resource "aws_s3_bucket" "product-import" {
   force_destroy = var.s3_force_destroy
 
   # Requires change to Spree code to work - reapply as part of SINF-402
-  #server_side_encryption_configuration {
-  #  rule {
-  #    apply_server_side_encryption_by_default {
-  #      sse_algorithm = "AES256"
-  #    }
-  #  }
-  #}
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
   versioning {
     enabled = true


### PR DESCRIPTION
Add encryption for S3 and Redis  by uncommenting the code from PR [#85](https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-bat/pull/85)

Also adding extra `s` in redis_url  i.e from `redis://...` to `rediss://...` as this will set [`ssl: true`](https://github.com/redis/redis-rb/issues/771)

Please note:  I update ECR image on sbx3  to `sbx3-latest`  to push the spree changes up for testing



