### PR TITLE
Add sftp bucket to iam

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -441,7 +441,7 @@ module "iam" {
   source                   = "../../iam"
   environment              = var.environment
 
-  spree_bucket_access_arns = [module.s3.s3_static_bucket_arn, module.s3.s3_cnet_bucket_arn, module.s3.s3_product_import_bucket_arn]
+  spree_bucket_access_arns = [module.s3.s3_static_bucket_arn, module.s3.s3_cnet_bucket_arn, module.s3.s3_product_import_bucket_arn, "arn:aws:s3:::${local.suppliers_sftp_bucket}"]
 }
 
 module "memcached" {


### PR DESCRIPTION
Adding `"arn:aws:s3:::${local.suppliers_sftp_bucket}"` back as it was removed by  mistake.