### PR TITLE
fix ENABLE_ADMIN_PANEL_ORDERS true for all environments

### DIFF
--- a/terraform/modules/services/spree/spree.json.tpl
+++ b/terraform/modules/services/spree/spree.json.tpl
@@ -240,6 +240,10 @@
         "value": "${rack_timeout_service_timeout}"
       },
       {
+        "name": "ENABLE_ADMIN_PANEL_ORDERS",
+        "value": "${enable_admin_panel_orders}"
+      },
+      {
         "name": "LOG_LEVEL",
         "value": "${log_level}"
       }


### PR DESCRIPTION
After deploy PR [#96 ](https://github.com/Crown-Commercial-Service/ccs-scale-infra-services-bat/pull/96) i notice that ENABLE_ADMIN_PANEL_ORDERS wasn't set in spree services.  It was only set in sidekiq service.  I have deploy this to SBX3 and is set in sidekiq and spree.