### PR TITLE
SINF-436 - removed public IP from EC2 instances (SecurityHub fix)

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -32,7 +32,7 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
   iam_instance_profile        = aws_iam_instance_profile.ecs_agent.name
   user_data                   = data.template_file.user_data.rendered
   instance_type               = var.ec2_instance_type
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   key_name                    = "${lower(var.environment)}-spree-key"
   security_groups             = var.security_group_ids
 


### PR DESCRIPTION
Removed public IP address from ECS/EC2 instances.

A deploy didn't seem to change the setting for me - but terminating the EC2 instances and have them recreate did it.