### PR TITLE
Feature/sinf 435 instance metadata

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -40,6 +40,7 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
     create_before_destroy = true
   }
 
+  # Enforce use of Instance Metadata Service v2
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -39,6 +39,11 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
   lifecycle {
     create_before_destroy = true
   }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
 }
 
 data "template_file" "user_data" {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -45,6 +45,10 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
     http_endpoint = "enabled"
     http_tokens   = "required"
   }
+
+  root_block_device {
+    encrypted = true
+  }
 }
 
 data "template_file" "user_data" {


### PR DESCRIPTION
This enforces use of Instance Metadata Service V2 (IMDSv2) on ECS EC2 instances (SecurityHub issue).

I terminated the instances and recreated. 

The same approach does not work on the Bastion - as it is incompatible with instance connect I believe. However, creating an SSH tunnel via the (unchanged) Bastion still seemed to work (I will update ticket re what to do about Bastion EC2 instances)